### PR TITLE
Add OMEN key app launch binding

### DIFF
--- a/OmenHardware.cs
+++ b/OmenHardware.cs
@@ -928,7 +928,7 @@ namespace OmenSuperHub {
         var consumerClass = new ManagementClass(scope, new ManagementPath("CommandLineEventConsumer"), null);
         var consumer = consumerClass.CreateInstance();
         string currentPath = AppDomain.CurrentDomain.BaseDirectory;
-        if (method == "custom") {
+        if (method == "custom" || method == "app") {
           consumer["CommandLineTemplate"] = @"cmd /c echo OmenKeyTriggered > \\.\pipe\OmenSuperHubPipe";
         } else {
           consumer["CommandLineTemplate"] = @"C:\Windows\System32\schtasks.exe /run /tn ""Omen Key""";

--- a/Program.Config.cs
+++ b/Program.Config.cs
@@ -568,6 +568,7 @@ namespace OmenSuperHub {
               key.SetValue("AlreadyRead", alreadyRead);
               key.SetValue("CustomIcon", customIcon);
               key.SetValue("OmenKey", omenKey);
+              key.SetValue("OmenKeyAppPath", omenKeyAppPath);
               if (hasNVIDIAGpu || hasAMDDiscreteGpu)
                 key.SetValue("MonitorGPU", monitorGPU);
               key.SetValue("MonitorCPU", monitorCPU);
@@ -640,6 +641,9 @@ namespace OmenSuperHub {
                   break;
                 case "OmenKey":
                   key.SetValue("OmenKey", omenKey);
+                  break;
+                case "OmenKeyAppPath":
+                  key.SetValue("OmenKeyAppPath", omenKeyAppPath);
                   break;
                 case "MonitorGPU":
                   key.SetValue("MonitorGPU", monitorGPU);
@@ -1030,6 +1034,7 @@ namespace OmenSuperHub {
             }
 
             omenKey = (string)key.GetValue("OmenKey", "default");
+            omenKeyAppPath = (string)key.GetValue("OmenKeyAppPath", "");
             switch (omenKey) {
               case "default":
                 checkFloatingTimer.Enabled = false;
@@ -1042,6 +1047,12 @@ namespace OmenSuperHub {
                 OmenKeyOff();
                 OmenKeyOn(omenKey);
                 UpdateCheckedState("omenKeyGroup", Strings.OmenKeyToggle);
+                break;
+              case "app":
+                checkFloatingTimer.Enabled = true;
+                OmenKeyOff();
+                OmenKeyOn(omenKey);
+                UpdateCheckedState("omenKeyGroup", Strings.OmenKeyLaunchApp);
                 break;
               case "none":
                 checkFloatingTimer.Enabled = false;

--- a/Program.Menu.cs
+++ b/Program.Menu.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
@@ -1131,6 +1132,47 @@ namespace OmenSuperHub {
         OmenKeyOn(omenKey);
         SaveConfig("OmenKey");
       }, false));
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyLaunchApp, "omenKeyGroup", (s, e) => {
+        if (string.IsNullOrWhiteSpace(omenKeyAppPath) || !File.Exists(omenKeyAppPath)) {
+          if (!SelectOmenKeyApp()) {
+            skipCheckedUpdate = true;
+            return;
+          }
+          SaveConfig("OmenKeyAppPath");
+        }
+        omenKey = "app";
+        checkFloatingTimer.Enabled = true;
+        OmenKeyOff();
+        OmenKeyOn(omenKey);
+        SaveConfig("OmenKey");
+      }, false));
+      omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
+      string appDisplayName = string.IsNullOrWhiteSpace(omenKeyAppPath)
+        ? Strings.OmenKeyNoAppSelected
+        : Path.GetFileName(omenKeyAppPath);
+      omenKeyMenu.DropDownItems.Add(new ToolStripMenuItem($"{Strings.OmenKeyCurrentApp}: {appDisplayName}") { Enabled = false });
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySelectApp, null, (s, e) => {
+        if (!SelectOmenKeyApp()) return;
+        SaveConfig("OmenKeyAppPath");
+        omenKey = "app";
+        checkFloatingTimer.Enabled = true;
+        OmenKeyOff();
+        OmenKeyOn(omenKey);
+        SaveConfig("OmenKey");
+        RefreshMenu();
+      }, false));
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyClearApp, null, (s, e) => {
+        omenKeyAppPath = "";
+        SaveConfig("OmenKeyAppPath");
+        if (omenKey == "app") {
+          omenKey = "none";
+          checkFloatingTimer.Enabled = false;
+          OmenKeyOff();
+          SaveConfig("OmenKey");
+        }
+        RefreshMenu();
+      }, false));
+      omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyNone, "omenKeyGroup", (s, e) => {
         omenKey = "none";
         checkFloatingTimer.Enabled = false;

--- a/Program.cs
+++ b/Program.cs
@@ -51,11 +51,11 @@ namespace OmenSuperHub {
     static int countRestore = 0, gpuClock = 0, maxFrameRate = -1;
     static int alreadyRead = 0, alreadyReadCode = 1000;
     static string currentPreset = "PresetCustom1", presetCustom1Name = Strings.PresetCustom1, presetCustom2Name = Strings.PresetCustom2, presetCustom3Name = Strings.PresetCustom3;
-    static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = "default", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
+    static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = "default", omenKeyAppPath = "", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
     static volatile bool monitorFan = false;
     static bool skipCheckedUpdate = false; // action 内拦截时置 true，阻止 CreateMenuItem 覆盖勾选
     static bool powerOnline = SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online;
-    static bool monitorCPU = true, monitorGPU = true, isConnectedToNVIDIA = true, prevIsConnectedToNVIDIA = true, checkFloating = false, isTwoBytePL4 = false;
+    static bool monitorCPU = true, monitorGPU = true, isConnectedToNVIDIA = true, prevIsConnectedToNVIDIA = true, omenKeyTriggered = false, isTwoBytePL4 = false;
     static bool hasNVIDIAGpu, hasAMDDiscreteGpu; // 启动时一次性检测，硬件状态不会改变
     static string monitorRefreshRate = "low"; // 刷新频率：low=1s, high=0.25s
     static List<int> fanSpeedNow = new List<int> { 20, 23, 0 };
@@ -241,7 +241,7 @@ namespace OmenSuperHub {
         getOmenKeyTask();
         checkFloatingTimer = new System.Windows.Forms.Timer();
         checkFloatingTimer.Interval = 100;
-        checkFloatingTimer.Tick += (s, e) => HandleFloatingBarToggle();
+        checkFloatingTimer.Tick += (s, e) => HandleOmenKeyAction();
         checkFloatingTimer.Start();
 
         // Restore last setting
@@ -1209,27 +1209,78 @@ namespace OmenSuperHub {
       return (int)interpolated;
     }
 
-    static void HandleFloatingBarToggle() {
-      if (checkFloating) {
-        checkFloating = false;
-        try {
-          using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\OmenSuperHub")) {
-            if (key != null) {
-              if ((string)key.GetValue("FloatingBar", "off") == "on") {
-                floatingBar = "off";
-                CloseFloatingForm();
-                UpdateCheckedState("floatingBarGroup", Strings.FloatingHide);
-              } else {
-                floatingBar = "on";
-                ShowFloatingForm();
-                UpdateCheckedState("floatingBarGroup", Strings.FloatingShow);
-              }
-              SaveConfig("FloatingBar");
+    static void HandleOmenKeyAction() {
+      if (!omenKeyTriggered) return;
+
+      omenKeyTriggered = false;
+      if (omenKey == "custom") {
+        ToggleFloatingBarByOmenKey();
+      } else if (omenKey == "app") {
+        LaunchOmenKeyApp();
+      }
+    }
+
+    static void ToggleFloatingBarByOmenKey() {
+      try {
+        using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\OmenSuperHub")) {
+          if (key != null) {
+            if ((string)key.GetValue("FloatingBar", "off") == "on") {
+              floatingBar = "off";
+              CloseFloatingForm();
+              UpdateCheckedState("floatingBarGroup", Strings.FloatingHide);
+            } else {
+              floatingBar = "on";
+              ShowFloatingForm();
+              UpdateCheckedState("floatingBarGroup", Strings.FloatingShow);
             }
+            SaveConfig("FloatingBar");
           }
-        } catch (Exception ex) {
-          Logger.Error($"Error restoring configuration: {ex.Message}");
         }
+      } catch (Exception ex) {
+        Logger.Error($"Error restoring configuration: {ex.Message}");
+      }
+    }
+
+    static void LaunchOmenKeyApp() {
+      if (string.IsNullOrWhiteSpace(omenKeyAppPath) || !File.Exists(omenKeyAppPath)) {
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppNotFound, Strings.Hint, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        return;
+      }
+
+      try {
+        string workingDirectory = Path.GetDirectoryName(omenKeyAppPath);
+        var startInfo = new ProcessStartInfo {
+          FileName = omenKeyAppPath,
+          UseShellExecute = true
+        };
+        if (!string.IsNullOrWhiteSpace(workingDirectory)) {
+          startInfo.WorkingDirectory = workingDirectory;
+        }
+        Process.Start(startInfo);
+      } catch (Exception ex) {
+        Logger.Error($"Failed to launch Omen key app: {ex.Message}");
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppLaunchFailed(ex.Message), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+      }
+    }
+
+    static bool SelectOmenKeyApp() {
+      using (var dialog = new System.Windows.Forms.OpenFileDialog()) {
+        dialog.Title = Strings.OmenKeySelectApp;
+        dialog.Filter = Strings.OmenKeyAppFilter;
+        dialog.CheckFileExists = true;
+        dialog.Multiselect = false;
+        dialog.RestoreDirectory = true;
+
+        if (!string.IsNullOrWhiteSpace(omenKeyAppPath) && File.Exists(omenKeyAppPath)) {
+          dialog.InitialDirectory = Path.GetDirectoryName(omenKeyAppPath);
+          dialog.FileName = Path.GetFileName(omenKeyAppPath);
+        } else {
+          dialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        }
+
+        if (dialog.ShowDialog() != DialogResult.OK) return false;
+        omenKeyAppPath = dialog.FileName;
+        return true;
       }
     }
 
@@ -1244,8 +1295,8 @@ namespace OmenSuperHub {
               pipeServer.WaitForConnection();    // 若需要支持取消，可用异步版本
               using (var reader = new StreamReader(pipeServer)) {
                 string message = reader.ReadToEnd();
-                if (message.Contains("OmenKeyTriggered") && !checkFloating)
-                  checkFloating = true;
+                if (message.Contains("OmenKeyTriggered") && !omenKeyTriggered)
+                  omenKeyTriggered = true;
               }
             }
           } catch (Exception) when (token.IsCancellationRequested) {
@@ -1327,7 +1378,7 @@ namespace OmenSuperHub {
 
     static void Exit() {
       _pipeCts?.Cancel();
-      if (omenKey == "custom") {
+      if (omenKey == "custom" || omenKey == "app") {
         OmenKeyOff();
       }
       tooltipUpdateTimer.Stop(); // 停止定时器

--- a/Strings.cs
+++ b/Strings.cs
@@ -426,6 +426,23 @@
     // ─────────────────────────────────────────────────────────────────────────
     public static string OmenKeyDefault => T("默认", "預設", "Default");
     public static string OmenKeyToggle => T("切换浮窗显示", "切換浮窗顯示", "Toggle Overlay");
+    public static string OmenKeyLaunchApp => T("打开应用", "開啟應用程式", "Open App");
+    public static string OmenKeySelectApp => T("选择应用", "選擇應用程式", "Select App");
+    public static string OmenKeyClearApp => T("清除应用绑定", "清除應用程式綁定", "Clear App Binding");
+    public static string OmenKeyCurrentApp => T("当前应用", "目前應用程式", "Current App");
+    public static string OmenKeyNoAppSelected => T("未选择", "未選擇", "Not Selected");
+    public static string OmenKeyAppFilter => T(
+        "应用程序和快捷方式|*.exe;*.lnk;*.bat;*.cmd|所有文件|*.*",
+        "應用程式和捷徑|*.exe;*.lnk;*.bat;*.cmd|所有檔案|*.*",
+        "Applications and shortcuts|*.exe;*.lnk;*.bat;*.cmd|All files|*.*");
+    public static string OmenKeyAppNotFound => T(
+        "未找到已绑定的应用，请重新选择。",
+        "找不到已綁定的應用程式，請重新選擇。",
+        "The bound app was not found. Please select it again.");
+    public static string OmenKeyAppLaunchFailed(string msg) => T(
+        $"打开应用失败：{msg}",
+        $"開啟應用程式失敗：{msg}",
+        $"Failed to open app: {msg}");
     public static string OmenKeyNone => T("取消绑定", "取消綁定", "Unbound");
 
     // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
新增 OMEN 键“打开应用”绑定能力。

**变更内容**
- 在 `Omen键` 托盘菜单中新增：
  - `打开应用`
  - `选择应用`
  - `清除应用绑定`
  - 当前绑定应用显示
- 支持选择并启动 `.exe`、`.lnk`、`.bat`、`.cmd` 文件。
- 新增 `OmenKeyAppPath` 注册表配置，用于持久化绑定的应用路径。
- 将 OMEN 键触发逻辑从单一“切换浮窗”扩展为动作分发：
  - `custom`：切换浮窗
  - `app`：打开绑定应用
  - `default`：保持原默认行为
  - `none`：取消绑定
- 补充简体中文、繁体中文、英文 UI 文案。

**验证**
- 使用 VS 2022 MSBuild 构建通过：

```powershell
MSBuild.exe OmenSuperHub.sln /p:Configuration=Debug /p:Platform=x64 /v:minimal
```

**提交**
- `0ad9ced Add OMEN key app launch binding`