### PR TITLE
添加 Omen 键预设切换功能

### DIFF
--- a/OmenHardware.cs
+++ b/OmenHardware.cs
@@ -928,7 +928,7 @@ namespace OmenSuperHub {
         var consumerClass = new ManagementClass(scope, new ManagementPath("CommandLineEventConsumer"), null);
         var consumer = consumerClass.CreateInstance();
         string currentPath = AppDomain.CurrentDomain.BaseDirectory;
-        if (method == "custom" || method == "app") {
+        if (method == "custom" || method == "app" || method == "preset") {
           consumer["CommandLineTemplate"] = @"cmd /c echo OmenKeyTriggered > \\.\pipe\OmenSuperHubPipe";
         } else {
           consumer["CommandLineTemplate"] = @"C:\Windows\System32\schtasks.exe /run /tn ""Omen Key""";

--- a/Program.Config.cs
+++ b/Program.Config.cs
@@ -581,6 +581,7 @@ namespace OmenSuperHub {
               key.SetValue("CustomIcon", customIcon);
               key.SetValue("OmenKey", omenKey);
               key.SetValue("OmenKeyAppPath", omenKeyAppPath);
+              key.SetValue("OmenKeyPresetCandidates", omenKeyPresetCandidates);
               if (hasNVIDIAGpu || hasAMDDiscreteGpu)
                 key.SetValue("MonitorGPU", monitorGPU);
               key.SetValue("MonitorCPU", monitorCPU);
@@ -656,6 +657,9 @@ namespace OmenSuperHub {
                   break;
                 case "OmenKeyAppPath":
                   key.SetValue("OmenKeyAppPath", omenKeyAppPath);
+                  break;
+                case "OmenKeyPresetCandidates":
+                  key.SetValue("OmenKeyPresetCandidates", omenKeyPresetCandidates);
                   break;
                 case "MonitorGPU":
                   key.SetValue("MonitorGPU", monitorGPU);
@@ -784,26 +788,7 @@ namespace OmenSuperHub {
             presetCustom2Name = (string)key.GetValue("PresetCustom2Name", Strings.PresetCustom2);
             presetCustom3Name = (string)key.GetValue("PresetCustom3Name", Strings.PresetCustom3);
 
-            switch (currentPreset) {
-              case "PresetExtreme":
-                UpdateCheckedState("presetsGroup", Strings.PresetExtreme);
-                break;
-              case "PresetGpuPriority":
-                UpdateCheckedState("presetsGroup", Strings.PresetGpuPriority);
-                break;
-              case "PresetLightUse":
-                UpdateCheckedState("presetsGroup", Strings.PresetLightUse);
-                break;
-              case "PresetCustom1":
-                UpdateCheckedState("presetsGroup", Strings.PresetCustom1);
-                break;
-              case "PresetCustom2":
-                UpdateCheckedState("presetsGroup", Strings.PresetCustom2);
-                break;
-              case "PresetCustom3":
-                UpdateCheckedState("presetsGroup", Strings.PresetCustom3);
-                break;
-            }
+            UpdateCheckedState("presetsGroup", GetPresetDisplayName(currentPreset));
 
             if (currentPreset == "PresetExtreme" || currentPreset == "PresetGpuPriority" || currentPreset == "PresetLightUse") {
               fanTable = (string)key.GetValue("FanTable", fanTable);
@@ -1046,6 +1031,8 @@ namespace OmenSuperHub {
 
             omenKey = (string)key.GetValue("OmenKey", "default");
             omenKeyAppPath = (string)key.GetValue("OmenKeyAppPath", "");
+            omenKeyPresetCandidates = (string)key.GetValue("OmenKeyPresetCandidates", GetDefaultOmenKeyPresetCandidates());
+            GetOmenKeyPresetCandidateKeys();
             switch (omenKey) {
               case "default":
                 checkFloatingTimer.Enabled = false;
@@ -1064,6 +1051,12 @@ namespace OmenSuperHub {
                 OmenKeyOff();
                 OmenKeyOn(omenKey);
                 UpdateCheckedState("omenKeyGroup", Strings.OmenKeyLaunchApp);
+                break;
+              case "preset":
+                checkFloatingTimer.Enabled = true;
+                OmenKeyOff();
+                OmenKeyOn(omenKey);
+                UpdateCheckedState("omenKeyGroup", Strings.OmenKeySwitchPreset);
                 break;
               case "none":
                 checkFloatingTimer.Enabled = false;
@@ -1243,6 +1236,7 @@ namespace OmenSuperHub {
       }
       SaveConfig();
       RestoreConfig(isPreset: true);
+      UpdateTrayIconText();
     }
   }
 }

--- a/Program.Menu.cs
+++ b/Program.Menu.cs
@@ -53,6 +53,7 @@ namespace OmenSuperHub {
       }
 
       BuildTrayMenu(trayIcon.ContextMenuStrip);
+      UpdateTrayIconText();
 
       // Initialize tooltip update timer
       tooltipUpdateTimer = new System.Timers.Timer(1000); // Set interval to 1 second (low, default)
@@ -187,6 +188,9 @@ namespace OmenSuperHub {
               if (presetKey == "PresetCustom1") { presetCustom1Name = result; SaveConfig("PresetCustom1Name"); }
               if (presetKey == "PresetCustom2") { presetCustom2Name = result; SaveConfig("PresetCustom2Name"); }
               if (presetKey == "PresetCustom3") { presetCustom3Name = result; SaveConfig("PresetCustom3Name"); }
+              if (currentPreset == presetKey) {
+                UpdateTrayIconText();
+              }
             } else if (string.IsNullOrWhiteSpace(result)) {
               MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.RenamePresetError, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
@@ -1149,6 +1153,13 @@ namespace OmenSuperHub {
         OmenKeyOn(omenKey);
         SaveConfig("OmenKey");
       }, false));
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySwitchPreset, "omenKeyGroup", (s, e) => {
+        omenKey = "preset";
+        checkFloatingTimer.Enabled = true;
+        OmenKeyOff();
+        OmenKeyOn(omenKey);
+        SaveConfig("OmenKey");
+      }, false));
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyLaunchApp, "omenKeyGroup", (s, e) => {
         if (string.IsNullOrWhiteSpace(omenKeyAppPath) || !File.Exists(omenKeyAppPath)) {
           if (!SelectOmenKeyApp()) {
@@ -1164,6 +1175,58 @@ namespace OmenSuperHub {
         SaveConfig("OmenKey");
       }, false));
       omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
+
+      bool keepOmenKeyPresetCandidatesMenuOpen = false;
+      ToolStripMenuItem omenKeyPresetCandidatesMenu = new ToolStripMenuItem(Strings.OmenKeyPresetCandidates);
+      omenKeyPresetCandidatesMenu.DropDownItems.Add(new ToolStripMenuItem());
+      ToolStripDropDownClosingEventHandler keepPresetCandidatesMenuOpen = (s, e) => {
+        if (keepOmenKeyPresetCandidatesMenuOpen && e.CloseReason == ToolStripDropDownCloseReason.ItemClicked) {
+          e.Cancel = true;
+        }
+      };
+      menu.Closing += keepPresetCandidatesMenuOpen;
+      omenKeyMenu.DropDown.Closing += keepPresetCandidatesMenuOpen;
+      omenKeyPresetCandidatesMenu.DropDown.Closing += keepPresetCandidatesMenuOpen;
+      omenKeyPresetCandidatesMenu.DropDown.Closed += (s, e) => {
+        keepOmenKeyPresetCandidatesMenuOpen = false;
+      };
+      omenKeyPresetCandidatesMenu.DropDown.MouseLeave += (s, e) => {
+        var dropDown = omenKeyPresetCandidatesMenu.DropDown;
+        if (!dropDown.ClientRectangle.Contains(dropDown.PointToClient(Control.MousePosition))) {
+          dropDown.Close(ToolStripDropDownCloseReason.CloseCalled);
+        }
+      };
+      omenKeyPresetCandidatesMenu.DropDownOpening += (s, e) => {
+        omenKeyPresetCandidatesMenu.DropDownItems.Clear();
+        var selectedPresetKeys = GetOmenKeyPresetCandidateKeys();
+        foreach (string presetKey in GetAvailablePresetKeys()) {
+          string localPresetKey = presetKey;
+          var presetItem = new ToolStripMenuItem(GetPresetDisplayName(localPresetKey)) {
+            Checked = selectedPresetKeys.Contains(localPresetKey),
+            CheckOnClick = false
+          };
+          presetItem.MouseDown += (sender, args) => {
+            if (args.Button == MouseButtons.Left) {
+              keepOmenKeyPresetCandidatesMenuOpen = true;
+            }
+          };
+          presetItem.Click += (sender, args) => {
+            keepOmenKeyPresetCandidatesMenuOpen = true;
+            bool nextState = !presetItem.Checked;
+            if (SetOmenKeyPresetCandidate(localPresetKey, nextState)) {
+              presetItem.Checked = nextState;
+              SaveConfig("OmenKeyPresetCandidates");
+            } else {
+              presetItem.Checked = true;
+            }
+            menu.BeginInvoke(new Action(() => keepOmenKeyPresetCandidatesMenuOpen = false));
+          };
+          omenKeyPresetCandidatesMenu.DropDownItems.Add(presetItem);
+        }
+      };
+      omenKeyMenu.DropDownItems.Add(omenKeyPresetCandidatesMenu);
+      omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
+
       string appDisplayName = string.IsNullOrWhiteSpace(omenKeyAppPath)
         ? Strings.OmenKeyNoAppSelected
         : Path.GetFileName(omenKeyAppPath);

--- a/Program.cs
+++ b/Program.cs
@@ -50,8 +50,9 @@ namespace OmenSuperHub {
     static int textSize = 40;
     static int countRestore = 0, gpuClock = 0, maxFrameRate = -1;
     static int alreadyRead = 0, alreadyReadCode = 1000;
+    static readonly string[] PresetOrder = { "PresetExtreme", "PresetGpuPriority", "PresetLightUse", "PresetCustom1", "PresetCustom2", "PresetCustom3" };
     static string currentPreset = "PresetCustom1", presetCustom1Name = Strings.PresetCustom1, presetCustom2Name = Strings.PresetCustom2, presetCustom3Name = Strings.PresetCustom3;
-    static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = "default", omenKeyAppPath = "", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
+    static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = "default", omenKeyAppPath = "", omenKeyPresetCandidates = "", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
     static volatile bool monitorFan = false;
     static bool skipCheckedUpdate = false; // action 内拦截时置 true，阻止 CreateMenuItem 覆盖勾选
     static bool powerOnline = SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online;
@@ -899,7 +900,7 @@ namespace OmenSuperHub {
 
       if (monitorFan)
         fanSpeedNow = GetFanLevel();
-      trayIcon.Text = monitorText();
+      UpdateTrayIconText();
       //Console.WriteLine("UpdateTooltip");
 
       // 同步数据到本地txt
@@ -1217,6 +1218,8 @@ namespace OmenSuperHub {
         ToggleFloatingBarByOmenKey();
       } else if (omenKey == "app") {
         LaunchOmenKeyApp();
+      } else if (omenKey == "preset") {
+        SwitchPresetByOmenKey();
       }
     }
 
@@ -1261,6 +1264,112 @@ namespace OmenSuperHub {
         Logger.Error($"Failed to launch Omen key app: {ex.Message}");
         MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppLaunchFailed(ex.Message), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
       }
+    }
+
+    static bool IsPresetAvailable(string presetKey) {
+      switch (presetKey) {
+        case "PresetExtreme":
+        case "PresetGpuPriority":
+        case "PresetLightUse":
+          return isCPUPowerControlSupported;
+        case "PresetCustom1":
+        case "PresetCustom2":
+        case "PresetCustom3":
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    static List<string> GetAvailablePresetKeys() {
+      return PresetOrder.Where(IsPresetAvailable).ToList();
+    }
+
+    static string GetDefaultOmenKeyPresetCandidates() {
+      return string.Join(";", GetAvailablePresetKeys());
+    }
+
+    static List<string> GetOmenKeyPresetCandidateKeys() {
+      var available = GetAvailablePresetKeys();
+      var candidates = (omenKeyPresetCandidates ?? "")
+          .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+          .Where(available.Contains)
+          .Distinct()
+          .OrderBy(key => Array.IndexOf(PresetOrder, key))
+          .ToList();
+
+      if (candidates.Count == 0) {
+        if (IsPresetAvailable(currentPreset)) {
+          candidates.Add(currentPreset);
+        } else if (available.Count > 0) {
+          candidates.Add(available[0]);
+        }
+      }
+
+      omenKeyPresetCandidates = string.Join(";", candidates);
+      return candidates;
+    }
+
+    static bool SetOmenKeyPresetCandidate(string presetKey, bool enabled) {
+      if (!IsPresetAvailable(presetKey)) return false;
+
+      var candidates = GetOmenKeyPresetCandidateKeys();
+      if (enabled) {
+        if (!candidates.Contains(presetKey))
+          candidates.Add(presetKey);
+      } else {
+        if (candidates.Count <= 1 && candidates.Contains(presetKey))
+          return false;
+        candidates.Remove(presetKey);
+      }
+
+      candidates = candidates
+          .Distinct()
+          .OrderBy(key => Array.IndexOf(PresetOrder, key))
+          .ToList();
+      omenKeyPresetCandidates = string.Join(";", candidates);
+      return true;
+    }
+
+    static void SwitchPresetByOmenKey() {
+      var candidates = GetOmenKeyPresetCandidateKeys();
+      if (candidates.Count == 0) return;
+
+      int currentIndex = candidates.IndexOf(currentPreset);
+      string targetPreset = candidates[(currentIndex + 1) % candidates.Count];
+      if (targetPreset != currentPreset) {
+        applyPresetLogic(targetPreset);
+      } else {
+        UpdateTrayIconText();
+      }
+
+      ShowOmenKeyPresetNotification();
+    }
+
+    static void ShowOmenKeyPresetNotification() {
+      if (trayIcon == null) return;
+      ShowTrayBalloonTip(
+        Strings.OmenKeyPresetBalloonTitle,
+        Strings.OmenKeyPresetBalloonText(GetCurrentPresetDisplayName()),
+        ToolTipIcon.Info,
+        3000,
+        replaceExisting: true
+      );
+    }
+
+    static void ShowTrayBalloonTip(string title, string text, ToolTipIcon icon, int timeout, bool replaceExisting = false) {
+      if (trayIcon == null) return;
+
+      if (replaceExisting && trayIcon.Visible) {
+        trayIcon.Visible = false;
+        trayIcon.Visible = true;
+        UpdateTrayIconText();
+      }
+
+      trayIcon.BalloonTipTitle = title;
+      trayIcon.BalloonTipText = text;
+      trayIcon.BalloonTipIcon = icon;
+      trayIcon.ShowBalloonTip(timeout);
     }
 
     static bool SelectOmenKeyApp() {
@@ -1376,9 +1485,44 @@ namespace OmenSuperHub {
       return str;
     }
 
+    static string GetPresetDisplayName(string presetKey) {
+      switch (presetKey) {
+        case "PresetExtreme": return Strings.PresetExtreme;
+        case "PresetGpuPriority": return Strings.PresetGpuPriority;
+        case "PresetLightUse": return Strings.PresetLightUse;
+        case "PresetCustom1": return presetCustom1Name;
+        case "PresetCustom2": return presetCustom2Name;
+        case "PresetCustom3": return presetCustom3Name;
+        default: return presetKey;
+      }
+    }
+
+    static string GetCurrentPresetDisplayName() {
+      return GetPresetDisplayName(currentPreset);
+    }
+
+    static string GetActiveProfileStatusText() {
+      return $"{Strings.ActiveProfile}: {GetCurrentPresetDisplayName()}";
+    }
+
+    static void UpdateTrayIconText() {
+      if (trayIcon == null) return;
+
+      string text = GetActiveProfileStatusText();
+      string monitor = monitorText();
+      if (!string.IsNullOrWhiteSpace(monitor))
+        text += "\n" + monitor;
+
+      const int notifyIconTextLimit = 63;
+      if (text.Length > notifyIconTextLimit)
+        text = text.Substring(0, notifyIconTextLimit);
+
+      trayIcon.Text = text;
+    }
+
     static void Exit() {
       _pipeCts?.Cancel();
-      if (omenKey == "custom" || omenKey == "app") {
+      if (omenKey == "custom" || omenKey == "app" || omenKey == "preset") {
         OmenKeyOff();
       }
       tooltipUpdateTimer.Stop(); // 停止定时器

--- a/Strings.cs
+++ b/Strings.cs
@@ -59,6 +59,7 @@
     public static string PresetCustom1 => T("自定义预设1", "自定義預設1", "Custom 1");
     public static string PresetCustom2 => T("自定义预设2", "自定義預設2", "Custom 2");
     public static string PresetCustom3 => T("自定义预设3", "自定義預設3", "Custom 3");
+    public static string ActiveProfile => T("当前档案", "目前檔案", "Active Profile");
     public static string RenamePreset => T("重命名", "重新命名", "Rename");
     public static string RenamePresetTitle => T("重命名预设", "重新命名預設", "Rename Preset");
     public static string RenamePresetPrompt => T("请输入新的预设名称：", "請輸入新的預設名稱：", "Please enter new preset name:");
@@ -462,6 +463,13 @@
     // ─────────────────────────────────────────────────────────────────────────
     public static string OmenKeyDefault => T("默认", "預設", "Default");
     public static string OmenKeyToggle => T("切换浮窗显示", "切換浮窗顯示", "Toggle Overlay");
+    public static string OmenKeySwitchPreset => T("切换预设", "切換預設", "Switch Preset");
+    public static string OmenKeyPresetCandidates => T("切换候选预设", "切換候選預設", "Preset Candidates");
+    public static string OmenKeyPresetBalloonTitle => T("已切换预设", "已切換預設", "Preset Switched");
+    public static string OmenKeyPresetBalloonText(string name) => T(
+        $"当前预设：{name}",
+        $"目前預設：{name}",
+        $"Current preset: {name}");
     public static string OmenKeyLaunchApp => T("打开应用", "開啟應用程式", "Open App");
     public static string OmenKeySelectApp => T("选择应用", "選擇應用程式", "Select App");
     public static string OmenKeyClearApp => T("清除应用绑定", "清除應用程式綁定", "Clear App Binding");


### PR DESCRIPTION
## 改动概述

- 托盘图标提示中增加当前激活档案显示。
- Omen 键新增“切换预设”绑定选项。
- Omen 键菜单中新增“切换候选预设”子菜单，支持自定义参与轮换的预设列表。
- 优化候选预设子菜单交互，勾选多个候选项时不需要反复重新打开托盘菜单。
- 使用 Omen 键切换预设时弹出托盘通知，提示当前预设名称。
- 将 Omen 键候选预设列表写入配置并在启动时恢复。

## 测试

- 已通过 `Debug|x64` 构建测试。