### PR TITLE
支持 OMEN 键绑定 UWP 应用和模拟按键

### DIFF
--- a/OmenHardware.cs
+++ b/OmenHardware.cs
@@ -963,7 +963,7 @@ namespace OmenSuperHub {
         var consumerClass = new ManagementClass(scope, new ManagementPath("CommandLineEventConsumer"), null);
         var consumer = consumerClass.CreateInstance();
         string currentPath = AppDomain.CurrentDomain.BaseDirectory;
-        if (method == "custom" || method == "app" || method == "preset") {
+        if (OmenKeyActions.UsesPipe(method)) {
           consumer["CommandLineTemplate"] = @"cmd /c echo OmenKeyTriggered > \\.\pipe\OmenSuperHubPipe";
         } else {
           consumer["CommandLineTemplate"] = @"C:\Windows\System32\schtasks.exe /run /tn ""Omen Key""";

--- a/OmenSuperHub.csproj
+++ b/OmenSuperHub.csproj
@@ -315,6 +315,7 @@
     </Compile>
     <Compile Include="Program.Config.cs" />
     <Compile Include="Program.Menu.cs" />
+    <Compile Include="Program.OmenKey.cs" />
     <Compile Include="Properties\AssemblyVersion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Program.cs" />

--- a/Program.Config.cs
+++ b/Program.Config.cs
@@ -581,6 +581,8 @@ namespace OmenSuperHub {
               key.SetValue("CustomIcon", customIcon);
               key.SetValue("OmenKey", omenKey);
               key.SetValue("OmenKeyAppPath", omenKeyAppPath);
+              key.SetValue("OmenKeyAppName", omenKeyAppName);
+              key.SetValue("OmenKeyShortcut", omenKeyShortcut);
               key.SetValue("OmenKeyPresetCandidates", omenKeyPresetCandidates);
               if (hasNVIDIAGpu || hasAMDDiscreteGpu)
                 key.SetValue("MonitorGPU", monitorGPU);
@@ -657,6 +659,12 @@ namespace OmenSuperHub {
                   break;
                 case "OmenKeyAppPath":
                   key.SetValue("OmenKeyAppPath", omenKeyAppPath);
+                  break;
+                case "OmenKeyAppName":
+                  key.SetValue("OmenKeyAppName", omenKeyAppName);
+                  break;
+                case "OmenKeyShortcut":
+                  key.SetValue("OmenKeyShortcut", omenKeyShortcut);
                   break;
                 case "OmenKeyPresetCandidates":
                   key.SetValue("OmenKeyPresetCandidates", omenKeyPresetCandidates);
@@ -1127,17 +1135,13 @@ namespace OmenSuperHub {
             case "dynamic": UpdateDynamicIcon(); UpdateCheckedState("customIconGroup", Strings.IconDynamic); break;
           }
 
-          omenKey = (string)key.GetValue("OmenKey", "default");
+          omenKey = (string)key.GetValue("OmenKey", OmenKeyActions.Default);
           omenKeyAppPath = (string)key.GetValue("OmenKeyAppPath", "");
+          omenKeyAppName = (string)key.GetValue("OmenKeyAppName", "");
+          omenKeyShortcut = (string)key.GetValue("OmenKeyShortcut", "");
           omenKeyPresetCandidates = (string)key.GetValue("OmenKeyPresetCandidates", GetDefaultOmenKeyPresetCandidates());
           GetOmenKeyPresetCandidateKeys();
-          switch (omenKey) {
-            case "default": checkFloatingTimer.Enabled = false; OmenKeyOff(); OmenKeyOn(omenKey); UpdateCheckedState("omenKeyGroup", Strings.OmenKeyDefault); break;
-            case "custom": checkFloatingTimer.Enabled = true; OmenKeyOff(); OmenKeyOn(omenKey); UpdateCheckedState("omenKeyGroup", Strings.OmenKeyToggle); break;
-            case "app": checkFloatingTimer.Enabled = true; OmenKeyOff(); OmenKeyOn(omenKey); UpdateCheckedState("omenKeyGroup", Strings.OmenKeyLaunchApp); break;
-            case "preset": checkFloatingTimer.Enabled = true; OmenKeyOff(); OmenKeyOn(omenKey); UpdateCheckedState("omenKeyGroup", Strings.OmenKeySwitchPreset); break;
-            case "none": checkFloatingTimer.Enabled = false; OmenKeyOff(); UpdateCheckedState("omenKeyGroup", Strings.OmenKeyNone); break;
-          }
+          RestoreOmenKeyAction();
 
           textSize = (int)key.GetValue("FloatingBarSize", 40);
           UpdateFloatingText();

--- a/Program.Menu.cs
+++ b/Program.Menu.cs
@@ -1158,39 +1158,35 @@ namespace OmenSuperHub {
       menu.Items.Add(floatingBarMenu);
       ToolStripMenuItem omenKeyMenu = new ToolStripMenuItem(Strings.OmenKeyMenu);
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyDefault, "omenKeyGroup", (s, e) => {
-        omenKey = "default";
         tooltipUpdateTimer.Enabled = false;
-        OmenKeyOff();
-        OmenKeyOn(omenKey);
-        SaveConfig("OmenKey");
+        ApplyOmenKeyAction(OmenKeyActions.Default);
       }, true));
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyToggle, "omenKeyGroup", (s, e) => {
-        omenKey = "custom";
-        checkFloatingTimer.Enabled = true;
-        OmenKeyOff();
-        OmenKeyOn(omenKey);
-        SaveConfig("OmenKey");
+        ApplyOmenKeyAction(OmenKeyActions.Overlay);
       }, false));
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySwitchPreset, "omenKeyGroup", (s, e) => {
-        omenKey = "preset";
-        checkFloatingTimer.Enabled = true;
-        OmenKeyOff();
-        OmenKeyOn(omenKey);
-        SaveConfig("OmenKey");
+        ApplyOmenKeyAction(OmenKeyActions.Preset);
       }, false));
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyLaunchApp, "omenKeyGroup", (s, e) => {
-        if (string.IsNullOrWhiteSpace(omenKeyAppPath) || !File.Exists(omenKeyAppPath)) {
+        if (!IsOmenKeyAppTargetAvailable()) {
           if (!SelectOmenKeyApp()) {
             skipCheckedUpdate = true;
             return;
           }
           SaveConfig("OmenKeyAppPath");
+          SaveConfig("OmenKeyAppName");
         }
-        omenKey = "app";
-        checkFloatingTimer.Enabled = true;
-        OmenKeyOff();
-        OmenKeyOn(omenKey);
-        SaveConfig("OmenKey");
+        ApplyOmenKeyAction(OmenKeyActions.App);
+      }, false));
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyShortcut, "omenKeyGroup", (s, e) => {
+        if (string.IsNullOrWhiteSpace(omenKeyShortcut)) {
+          if (!SelectOmenKeyShortcut()) {
+            skipCheckedUpdate = true;
+            return;
+          }
+          SaveConfig("OmenKeyShortcut");
+        }
+        ApplyOmenKeyAction(OmenKeyActions.Shortcut);
       }, false));
       omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
 
@@ -1245,37 +1241,50 @@ namespace OmenSuperHub {
       omenKeyMenu.DropDownItems.Add(omenKeyPresetCandidatesMenu);
       omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
 
-      string appDisplayName = string.IsNullOrWhiteSpace(omenKeyAppPath)
-        ? Strings.OmenKeyNoAppSelected
-        : Path.GetFileName(omenKeyAppPath);
-      omenKeyMenu.DropDownItems.Add(new ToolStripMenuItem($"{Strings.OmenKeyCurrentApp}: {appDisplayName}") { Enabled = false });
-      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySelectApp, null, (s, e) => {
+      omenKeyMenu.DropDownItems.Add(new ToolStripMenuItem($"{Strings.OmenKeyCurrentApp}: {GetOmenKeyAppDisplayName()}") { Enabled = false });
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySelectDesktopApp, null, (s, e) => {
         if (!SelectOmenKeyApp()) return;
         SaveConfig("OmenKeyAppPath");
-        omenKey = "app";
-        checkFloatingTimer.Enabled = true;
-        OmenKeyOff();
-        OmenKeyOn(omenKey);
-        SaveConfig("OmenKey");
+        SaveConfig("OmenKeyAppName");
+        ApplyOmenKeyAction(OmenKeyActions.App);
+        RefreshMenu();
+      }, false));
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySelectUwpApp, null, (s, e) => {
+        if (!SelectOmenKeyUwpApp()) return;
+        SaveConfig("OmenKeyAppPath");
+        SaveConfig("OmenKeyAppName");
+        ApplyOmenKeyAction(OmenKeyActions.App);
         RefreshMenu();
       }, false));
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyClearApp, null, (s, e) => {
         omenKeyAppPath = "";
+        omenKeyAppName = "";
         SaveConfig("OmenKeyAppPath");
-        if (omenKey == "app") {
-          omenKey = "none";
-          checkFloatingTimer.Enabled = false;
-          OmenKeyOff();
-          SaveConfig("OmenKey");
+        SaveConfig("OmenKeyAppName");
+        if (omenKey == OmenKeyActions.App) {
+          ApplyOmenKeyAction(OmenKeyActions.None);
+        }
+        RefreshMenu();
+      }, false));
+      omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
+      omenKeyMenu.DropDownItems.Add(new ToolStripMenuItem($"{Strings.OmenKeyCurrentShortcut}: {FormatOmenKeyShortcut(omenKeyShortcut)}") { Enabled = false });
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeySetShortcut, null, (s, e) => {
+        if (!SelectOmenKeyShortcut()) return;
+        SaveConfig("OmenKeyShortcut");
+        ApplyOmenKeyAction(OmenKeyActions.Shortcut);
+        RefreshMenu();
+      }, false));
+      omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyClearShortcut, null, (s, e) => {
+        omenKeyShortcut = "";
+        SaveConfig("OmenKeyShortcut");
+        if (omenKey == OmenKeyActions.Shortcut) {
+          ApplyOmenKeyAction(OmenKeyActions.None);
         }
         RefreshMenu();
       }, false));
       omenKeyMenu.DropDownItems.Add(new ToolStripSeparator());
       omenKeyMenu.DropDownItems.Add(CreateMenuItem(Strings.OmenKeyNone, "omenKeyGroup", (s, e) => {
-        omenKey = "none";
-        checkFloatingTimer.Enabled = false;
-        OmenKeyOff();
-        SaveConfig("OmenKey");
+        ApplyOmenKeyAction(OmenKeyActions.None);
       }, false));
       menu.Items.Add(omenKeyMenu);
 

--- a/Program.OmenKey.cs
+++ b/Program.OmenKey.cs
@@ -1,0 +1,774 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+using Microsoft.Win32;
+using Newtonsoft.Json.Linq;
+using static OmenSuperHub.OmenHardware;
+
+namespace OmenSuperHub {
+  internal static class OmenKeyActions {
+    public const string Default = "default";
+    public const string Overlay = "custom"; // Registry compatibility: "custom" means toggle overlay.
+    public const string App = "app";
+    public const string Shortcut = "shortcut";
+    public const string Preset = "preset";
+    public const string None = "none";
+
+    public static bool UsesPipe(string action) {
+      return action == Overlay || action == App || action == Shortcut || action == Preset;
+    }
+
+    public static bool IsKnown(string action) {
+      return action == Default || action == Overlay || action == App ||
+          action == Shortcut || action == Preset || action == None;
+    }
+  }
+
+  static partial class Program {
+    [DllImport("user32.dll")]
+    static extern short GetAsyncKeyState(int vKey);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    const uint INPUT_KEYBOARD = 1;
+    const uint KEYEVENTF_KEYUP = 0x0002;
+    const int VK_SHIFT = 0x10;
+    const int VK_CONTROL = 0x11;
+    const int VK_MENU = 0x12;
+    const int VK_LWIN = 0x5B;
+    const int VK_RWIN = 0x5C;
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct INPUT {
+      public uint type;
+      public InputUnion u;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct InputUnion {
+      [FieldOffset(0)]
+      public KEYBDINPUT ki;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct KEYBDINPUT {
+      public ushort wVk;
+      public ushort wScan;
+      public uint dwFlags;
+      public uint time;
+      public IntPtr dwExtraInfo;
+    }
+
+    static void HandleOmenKeyAction() {
+      if (!omenKeyTriggered) return;
+
+      omenKeyTriggered = false;
+      switch (omenKey) {
+        case OmenKeyActions.Overlay:
+          ToggleFloatingBarByOmenKey();
+          break;
+        case OmenKeyActions.App:
+          LaunchOmenKeyApp();
+          break;
+        case OmenKeyActions.Shortcut:
+          SendOmenKeyShortcut();
+          break;
+        case OmenKeyActions.Preset:
+          SwitchPresetByOmenKey();
+          break;
+      }
+    }
+
+    static void ApplyOmenKeyAction(string action, bool save = true) {
+      omenKey = OmenKeyActions.IsKnown(action) ? action : OmenKeyActions.Default;
+      checkFloatingTimer.Enabled = OmenKeyActions.UsesPipe(omenKey);
+
+      OmenKeyOff();
+      if (omenKey != OmenKeyActions.None)
+        OmenKeyOn(omenKey);
+
+      if (save)
+        SaveConfig("OmenKey");
+    }
+
+    static void RestoreOmenKeyAction() {
+      ApplyOmenKeyAction(omenKey, save: false);
+      UpdateCheckedState("omenKeyGroup", GetOmenKeyActionMenuText(omenKey));
+    }
+
+    static string GetOmenKeyActionMenuText(string action) {
+      switch (action) {
+        case OmenKeyActions.Default:
+          return Strings.OmenKeyDefault;
+        case OmenKeyActions.Overlay:
+          return Strings.OmenKeyToggle;
+        case OmenKeyActions.App:
+          return Strings.OmenKeyLaunchApp;
+        case OmenKeyActions.Shortcut:
+          return Strings.OmenKeyShortcut;
+        case OmenKeyActions.Preset:
+          return Strings.OmenKeySwitchPreset;
+        case OmenKeyActions.None:
+          return Strings.OmenKeyNone;
+        default:
+          return Strings.OmenKeyDefault;
+      }
+    }
+
+    static void ToggleFloatingBarByOmenKey() {
+      try {
+        using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\OmenSuperHub")) {
+          if (key != null) {
+            if ((string)key.GetValue("FloatingBar", "off") == "on") {
+              floatingBar = "off";
+              CloseFloatingForm();
+              UpdateCheckedState("floatingBarGroup", Strings.FloatingHide);
+            } else {
+              floatingBar = "on";
+              ShowFloatingForm();
+              UpdateCheckedState("floatingBarGroup", Strings.FloatingShow);
+            }
+            SaveConfig("FloatingBar");
+          }
+        }
+      } catch (Exception ex) {
+        Logger.Error($"Error restoring configuration: {ex.Message}");
+      }
+    }
+
+    static void LaunchOmenKeyApp() {
+      if (!IsOmenKeyAppTargetAvailable()) {
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppNotFound, Strings.Hint, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        return;
+      }
+
+      try {
+        if (IsOmenKeyShellAppTarget(omenKeyAppPath)) {
+          Process.Start(new ProcessStartInfo {
+            FileName = "explorer.exe",
+            Arguments = QuoteProcessArgument(omenKeyAppPath),
+            UseShellExecute = false
+          });
+        } else {
+          string workingDirectory = Path.GetDirectoryName(omenKeyAppPath);
+          var startInfo = new ProcessStartInfo {
+            FileName = omenKeyAppPath,
+            UseShellExecute = true
+          };
+          if (!string.IsNullOrWhiteSpace(workingDirectory)) {
+            startInfo.WorkingDirectory = workingDirectory;
+          }
+          Process.Start(startInfo);
+        }
+      } catch (Exception ex) {
+        Logger.Error($"Failed to launch Omen key app: {ex.Message}");
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppLaunchFailed(ex.Message), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+      }
+    }
+
+    static bool IsOmenKeyShellAppTarget(string target) {
+      return !string.IsNullOrWhiteSpace(target) && target.StartsWith("shell:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool IsOmenKeyAppTargetAvailable() {
+      if (string.IsNullOrWhiteSpace(omenKeyAppPath)) return false;
+      return IsOmenKeyShellAppTarget(omenKeyAppPath) || File.Exists(omenKeyAppPath);
+    }
+
+    static string QuoteProcessArgument(string value) {
+      if (value == null) return "\"\"";
+      return "\"" + value.Replace("\"", "\\\"") + "\"";
+    }
+
+    static string GetOmenKeyAppDisplayName() {
+      if (string.IsNullOrWhiteSpace(omenKeyAppPath)) return Strings.OmenKeyNoAppSelected;
+      if (IsOmenKeyShellAppTarget(omenKeyAppPath)) {
+        return string.IsNullOrWhiteSpace(omenKeyAppName) ? GetOmenKeyUwpAppId() : omenKeyAppName;
+      }
+      return Path.GetFileName(omenKeyAppPath);
+    }
+
+    static string GetOmenKeyUwpAppId() {
+      const string prefix = @"shell:AppsFolder\";
+      if (string.IsNullOrWhiteSpace(omenKeyAppPath)) return "";
+      if (omenKeyAppPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        return omenKeyAppPath.Substring(prefix.Length);
+      return omenKeyAppPath;
+    }
+
+    static bool IsPresetAvailable(string presetKey) {
+      switch (presetKey) {
+        case "PresetExtreme":
+        case "PresetGpuPriority":
+        case "PresetLightUse":
+          return isCPUPowerControlSupported;
+        case "PresetCustom1":
+        case "PresetCustom2":
+        case "PresetCustom3":
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    static List<string> GetAvailablePresetKeys() {
+      return PresetOrder.Where(IsPresetAvailable).ToList();
+    }
+
+    static string GetDefaultOmenKeyPresetCandidates() {
+      return string.Join(";", GetAvailablePresetKeys());
+    }
+
+    static List<string> GetOmenKeyPresetCandidateKeys() {
+      var available = GetAvailablePresetKeys();
+      var candidates = (omenKeyPresetCandidates ?? "")
+          .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+          .Where(available.Contains)
+          .Distinct()
+          .OrderBy(key => Array.IndexOf(PresetOrder, key))
+          .ToList();
+
+      if (candidates.Count == 0) {
+        if (IsPresetAvailable(currentPreset)) {
+          candidates.Add(currentPreset);
+        } else if (available.Count > 0) {
+          candidates.Add(available[0]);
+        }
+      }
+
+      omenKeyPresetCandidates = string.Join(";", candidates);
+      return candidates;
+    }
+
+    static bool SetOmenKeyPresetCandidate(string presetKey, bool enabled) {
+      if (!IsPresetAvailable(presetKey)) return false;
+
+      var candidates = GetOmenKeyPresetCandidateKeys();
+      if (enabled) {
+        if (!candidates.Contains(presetKey))
+          candidates.Add(presetKey);
+      } else {
+        if (candidates.Count <= 1 && candidates.Contains(presetKey))
+          return false;
+        candidates.Remove(presetKey);
+      }
+
+      candidates = candidates
+          .Distinct()
+          .OrderBy(key => Array.IndexOf(PresetOrder, key))
+          .ToList();
+      omenKeyPresetCandidates = string.Join(";", candidates);
+      return true;
+    }
+
+    static void SwitchPresetByOmenKey() {
+      var candidates = GetOmenKeyPresetCandidateKeys();
+      if (candidates.Count == 0) return;
+
+      int currentIndex = candidates.IndexOf(currentPreset);
+      string targetPreset = candidates[(currentIndex + 1) % candidates.Count];
+      if (targetPreset != currentPreset) {
+        applyPresetLogic(targetPreset);
+      } else {
+        UpdateTrayIconText();
+      }
+
+      ShowOmenKeyPresetNotification();
+    }
+
+    static void ShowOmenKeyPresetNotification() {
+      if (trayIcon == null) return;
+
+      if (trayIcon.ContextMenuStrip != null && trayIcon.ContextMenuStrip.Visible) {
+        return;
+      }
+
+      trayIcon.BalloonTipTitle = Strings.OmenKeyPresetBalloonTitle;
+      trayIcon.BalloonTipText = Strings.OmenKeyPresetBalloonText(GetCurrentPresetDisplayName());
+      trayIcon.BalloonTipIcon = ToolTipIcon.Info;
+      trayIcon.ShowBalloonTip(3000);
+    }
+
+    static bool SelectOmenKeyApp() {
+      using (var dialog = new System.Windows.Forms.OpenFileDialog()) {
+        dialog.Title = Strings.OmenKeySelectApp;
+        dialog.Filter = Strings.OmenKeyAppFilter;
+        dialog.CheckFileExists = true;
+        dialog.Multiselect = false;
+        dialog.RestoreDirectory = true;
+
+        if (!string.IsNullOrWhiteSpace(omenKeyAppPath) && File.Exists(omenKeyAppPath)) {
+          dialog.InitialDirectory = Path.GetDirectoryName(omenKeyAppPath);
+          dialog.FileName = Path.GetFileName(omenKeyAppPath);
+        } else {
+          dialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        }
+
+        if (dialog.ShowDialog() != DialogResult.OK) return false;
+        omenKeyAppPath = dialog.FileName;
+        omenKeyAppName = "";
+        return true;
+      }
+    }
+
+    class OmenKeyStartApp {
+      public string Name { get; set; }
+      public string AppId { get; set; }
+    }
+
+    static List<OmenKeyStartApp> LoadStartApps() {
+      string command = "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+          "Get-StartApps | Sort-Object Name | Select-Object Name, AppID | ConvertTo-Json -Compress";
+      string encodedCommand = Convert.ToBase64String(Encoding.Unicode.GetBytes(command));
+      var startInfo = new ProcessStartInfo {
+        FileName = "powershell.exe",
+        Arguments = "-NoProfile -ExecutionPolicy Bypass -EncodedCommand " + encodedCommand,
+        UseShellExecute = false,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        CreateNoWindow = true,
+        StandardOutputEncoding = Encoding.UTF8,
+        StandardErrorEncoding = Encoding.UTF8
+      };
+
+      using (var process = new Process { StartInfo = startInfo }) {
+        process.Start();
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(10000)) {
+          try { process.Kill(); } catch { }
+          throw new TimeoutException("Get-StartApps timed out.");
+        }
+
+        string output = outputTask.Result;
+        string error = errorTask.Result;
+        if (process.ExitCode != 0) {
+          throw new InvalidOperationException(string.IsNullOrWhiteSpace(error) ? "Get-StartApps failed." : error.Trim());
+        }
+
+        if (string.IsNullOrWhiteSpace(output)) return new List<OmenKeyStartApp>();
+        JToken token = JToken.Parse(output);
+        IEnumerable<JToken> items;
+        if (token.Type == JTokenType.Array) {
+          items = token.Children();
+        } else {
+          items = new[] { token };
+        }
+        return items
+            .Select(item => new OmenKeyStartApp {
+              Name = (string)item["Name"],
+              AppId = (string)item["AppID"]
+            })
+            .Where(app => !string.IsNullOrWhiteSpace(app.Name) && !string.IsNullOrWhiteSpace(app.AppId))
+            .GroupBy(app => app.AppId, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .OrderBy(app => app.Name, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+      }
+    }
+
+    static bool SelectOmenKeyUwpApp() {
+      List<OmenKeyStartApp> apps;
+      try {
+        apps = LoadStartApps();
+      } catch (Exception ex) {
+        Logger.Error($"Failed to load UWP apps: {ex.Message}");
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyUwpLoadFailed(ex.Message), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        return false;
+      }
+
+      if (apps.Count == 0) {
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyUwpNoApps, Strings.Hint, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        return false;
+      }
+
+      using (var form = new Form()) {
+        form.Text = Strings.OmenKeySelectUwpApp;
+        form.StartPosition = FormStartPosition.CenterScreen;
+        form.Width = 720;
+        form.Height = 520;
+        form.MinimizeBox = false;
+        form.MaximizeBox = false;
+        form.ShowIcon = false;
+
+        var searchBox = new TextBox {
+          Left = 12,
+          Top = 12,
+          Width = form.ClientSize.Width - 24,
+          Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
+        };
+
+        var listView = new ListView {
+          Left = 12,
+          Top = searchBox.Bottom + 8,
+          Width = form.ClientSize.Width - 24,
+          Height = form.ClientSize.Height - 92,
+          Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
+          View = View.Details,
+          FullRowSelect = true,
+          HideSelection = false,
+          MultiSelect = false
+        };
+        listView.Columns.Add(Strings.OmenKeyUwpAppName, 240);
+        listView.Columns.Add("AppID", 420);
+
+        var okButton = new Button {
+          Text = Strings.OK,
+          Width = 92,
+          Height = 28,
+          Left = form.ClientSize.Width - 204,
+          Top = form.ClientSize.Height - 40,
+          Anchor = AnchorStyles.Bottom | AnchorStyles.Right,
+          Enabled = false
+        };
+        var cancelButton = new Button {
+          Text = Strings.Cancel,
+          Width = 92,
+          Height = 28,
+          Left = form.ClientSize.Width - 104,
+          Top = form.ClientSize.Height - 40,
+          Anchor = AnchorStyles.Bottom | AnchorStyles.Right,
+          DialogResult = DialogResult.Cancel
+        };
+
+        Action refreshList = () => {
+          string filter = searchBox.Text.Trim();
+          listView.BeginUpdate();
+          listView.Items.Clear();
+          foreach (var app in apps.Where(app =>
+              string.IsNullOrWhiteSpace(filter) ||
+              app.Name.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0 ||
+              app.AppId.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)) {
+            var item = new ListViewItem(app.Name);
+            item.SubItems.Add(app.AppId);
+            item.Tag = app;
+            listView.Items.Add(item);
+          }
+
+          string currentAppId = GetOmenKeyUwpAppId();
+          foreach (ListViewItem item in listView.Items) {
+            var app = (OmenKeyStartApp)item.Tag;
+            if (!string.IsNullOrWhiteSpace(currentAppId) && string.Equals(app.AppId, currentAppId, StringComparison.OrdinalIgnoreCase)) {
+              item.Selected = true;
+              item.Focused = true;
+              item.EnsureVisible();
+              break;
+            }
+          }
+          if (listView.SelectedItems.Count == 0 && listView.Items.Count > 0) {
+            listView.Items[0].Selected = true;
+            listView.Items[0].Focused = true;
+          }
+          okButton.Enabled = listView.SelectedItems.Count > 0;
+          listView.EndUpdate();
+        };
+
+        searchBox.TextChanged += (s, e) => refreshList();
+        listView.SelectedIndexChanged += (s, e) => okButton.Enabled = listView.SelectedItems.Count > 0;
+        listView.DoubleClick += (s, e) => {
+          if (listView.SelectedItems.Count > 0) okButton.PerformClick();
+        };
+        okButton.Click += (s, e) => {
+          if (listView.SelectedItems.Count == 0) return;
+          form.DialogResult = DialogResult.OK;
+          form.Close();
+        };
+
+        form.Controls.Add(searchBox);
+        form.Controls.Add(listView);
+        form.Controls.Add(okButton);
+        form.Controls.Add(cancelButton);
+        form.CancelButton = cancelButton;
+        refreshList();
+
+        if (form.ShowDialog(Application.OpenForms.OfType<HelpForm>().FirstOrDefault()) != DialogResult.OK)
+          return false;
+
+        var selectedApp = (OmenKeyStartApp)listView.SelectedItems[0].Tag;
+        omenKeyAppPath = @"shell:AppsFolder\" + selectedApp.AppId;
+        omenKeyAppName = selectedApp.Name;
+        return true;
+      }
+    }
+
+    static void SendOmenKeyShortcut() {
+      List<ushort> modifierKeys;
+      ushort keyCode;
+      if (!TryParseOmenKeyShortcut(omenKeyShortcut, out modifierKeys, out keyCode)) {
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyShortcutNotSet, Strings.Hint, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        return;
+      }
+
+      var inputs = new List<INPUT>();
+      foreach (ushort modifier in modifierKeys) {
+        inputs.Add(CreateKeyboardInput(modifier, false));
+      }
+      inputs.Add(CreateKeyboardInput(keyCode, false));
+      inputs.Add(CreateKeyboardInput(keyCode, true));
+      for (int i = modifierKeys.Count - 1; i >= 0; i--) {
+        inputs.Add(CreateKeyboardInput(modifierKeys[i], true));
+      }
+
+      uint sent = SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf(typeof(INPUT)));
+      if (sent != inputs.Count) {
+        int error = Marshal.GetLastWin32Error();
+        Logger.Error($"Failed to send Omen key shortcut. Sent {sent}/{inputs.Count}, Win32Error={error}");
+        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyShortcutSendFailed(error), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+      }
+    }
+
+    static INPUT CreateKeyboardInput(ushort keyCode, bool keyUp) {
+      return new INPUT {
+        type = INPUT_KEYBOARD,
+        u = new InputUnion {
+          ki = new KEYBDINPUT {
+            wVk = keyCode,
+            wScan = 0,
+            dwFlags = keyUp ? KEYEVENTF_KEYUP : 0,
+            time = 0,
+            dwExtraInfo = IntPtr.Zero
+          }
+        }
+      };
+    }
+
+    static bool SelectOmenKeyShortcut() {
+      using (var form = new Form()) {
+        form.Text = Strings.OmenKeySetShortcut;
+        form.StartPosition = FormStartPosition.CenterScreen;
+        form.Width = 440;
+        form.Height = 180;
+        form.MinimizeBox = false;
+        form.MaximizeBox = false;
+        form.ShowIcon = false;
+        form.KeyPreview = true;
+
+        var promptLabel = new Label {
+          Left = 12,
+          Top = 12,
+          Width = form.ClientSize.Width - 24,
+          Height = 36,
+          Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+          Text = Strings.OmenKeyShortcutCapturePrompt
+        };
+        var shortcutBox = new TextBox {
+          Left = 12,
+          Top = promptLabel.Bottom + 8,
+          Width = form.ClientSize.Width - 24,
+          Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+          ReadOnly = true,
+          TabStop = false,
+          Text = FormatOmenKeyShortcut(omenKeyShortcut)
+        };
+        var okButton = new Button {
+          Text = Strings.OK,
+          Width = 92,
+          Height = 28,
+          Left = form.ClientSize.Width - 304,
+          Top = form.ClientSize.Height - 44,
+          Anchor = AnchorStyles.Bottom | AnchorStyles.Right,
+          Enabled = !string.IsNullOrWhiteSpace(omenKeyShortcut)
+        };
+        var clearButton = new Button {
+          Text = Strings.Clear,
+          Width = 92,
+          Height = 28,
+          Left = form.ClientSize.Width - 204,
+          Top = form.ClientSize.Height - 44,
+          Anchor = AnchorStyles.Bottom | AnchorStyles.Right
+        };
+        var cancelButton = new Button {
+          Text = Strings.Cancel,
+          Width = 92,
+          Height = 28,
+          Left = form.ClientSize.Width - 104,
+          Top = form.ClientSize.Height - 44,
+          Anchor = AnchorStyles.Bottom | AnchorStyles.Right,
+          DialogResult = DialogResult.Cancel
+        };
+
+        string capturedShortcut = omenKeyShortcut;
+        form.KeyDown += (s, e) => {
+          if (IsModifierKey(e.KeyCode)) {
+            e.SuppressKeyPress = true;
+            return;
+          }
+
+          bool winDown = IsWinKeyDown();
+          capturedShortcut = BuildOmenKeyShortcut(e.KeyCode, e.Modifiers, winDown);
+          shortcutBox.Text = FormatOmenKeyShortcut(capturedShortcut);
+          okButton.Enabled = !string.IsNullOrWhiteSpace(capturedShortcut);
+          e.SuppressKeyPress = true;
+        };
+        okButton.Click += (s, e) => {
+          if (string.IsNullOrWhiteSpace(capturedShortcut)) {
+            MessageBox.Show(form, Strings.OmenKeyShortcutNotSet, Strings.Hint, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+          }
+          form.DialogResult = DialogResult.OK;
+          form.Close();
+        };
+        clearButton.Click += (s, e) => {
+          capturedShortcut = "";
+          shortcutBox.Text = "";
+          okButton.Enabled = false;
+        };
+
+        form.Controls.Add(promptLabel);
+        form.Controls.Add(shortcutBox);
+        form.Controls.Add(okButton);
+        form.Controls.Add(clearButton);
+        form.Controls.Add(cancelButton);
+        form.CancelButton = cancelButton;
+
+        if (form.ShowDialog(Application.OpenForms.OfType<HelpForm>().FirstOrDefault()) != DialogResult.OK)
+          return false;
+
+        omenKeyShortcut = capturedShortcut;
+        return true;
+      }
+    }
+
+    static bool IsWinKeyDown() {
+      return (GetAsyncKeyState(VK_LWIN) & unchecked((short)0x8000)) != 0 ||
+          (GetAsyncKeyState(VK_RWIN) & unchecked((short)0x8000)) != 0;
+    }
+
+    static bool IsModifierKey(Keys keyCode) {
+      return keyCode == Keys.ControlKey || keyCode == Keys.ShiftKey || keyCode == Keys.Menu ||
+          keyCode == Keys.LWin || keyCode == Keys.RWin;
+    }
+
+    static string BuildOmenKeyShortcut(Keys keyCode, Keys modifiers, bool winDown) {
+      var parts = new List<string>();
+      if ((modifiers & Keys.Control) == Keys.Control) parts.Add("Ctrl");
+      if ((modifiers & Keys.Shift) == Keys.Shift) parts.Add("Shift");
+      if ((modifiers & Keys.Alt) == Keys.Alt) parts.Add("Alt");
+      if (winDown) parts.Add("Win");
+      parts.Add((keyCode & Keys.KeyCode).ToString());
+      return string.Join("+", parts);
+    }
+
+    static string FormatOmenKeyShortcut(string shortcut) {
+      if (string.IsNullOrWhiteSpace(shortcut)) return Strings.OmenKeyNoShortcutSelected;
+      return string.Join("+", shortcut
+          .Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries)
+          .Select(GetShortcutPartDisplayName));
+    }
+
+    static string GetShortcutPartDisplayName(string part) {
+      switch (part.Trim()) {
+        case "Control":
+        case "ControlKey":
+        case "Ctrl":
+          return "Ctrl";
+        case "Menu":
+        case "Alt":
+          return "Alt";
+        case "ShiftKey":
+        case "Shift":
+          return "Shift";
+        case "LWin":
+        case "RWin":
+        case "Win":
+          return "Win";
+        case "Escape":
+          return "Esc";
+        case "Return":
+          return "Enter";
+        case "Prior":
+          return "PageUp";
+        case "Next":
+          return "PageDown";
+        case "Snapshot":
+          return "PrintScreen";
+        case "OemMinus":
+          return "-";
+        case "Oemplus":
+          return "=";
+        case "Oemcomma":
+          return ",";
+        case "OemPeriod":
+          return ".";
+        default:
+          return part.Trim();
+      }
+    }
+
+    static bool TryParseOmenKeyShortcut(string shortcut, out List<ushort> modifierKeys, out ushort keyCode) {
+      modifierKeys = new List<ushort>();
+      keyCode = 0;
+      if (string.IsNullOrWhiteSpace(shortcut)) return false;
+
+      foreach (string rawPart in shortcut.Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries)) {
+        string part = rawPart.Trim();
+        switch (part.ToLowerInvariant()) {
+          case "ctrl":
+          case "control":
+          case "controlkey":
+            AddUniqueVirtualKey(modifierKeys, VK_CONTROL);
+            break;
+          case "shift":
+          case "shiftkey":
+            AddUniqueVirtualKey(modifierKeys, VK_SHIFT);
+            break;
+          case "alt":
+          case "menu":
+            AddUniqueVirtualKey(modifierKeys, VK_MENU);
+            break;
+          case "win":
+          case "lwin":
+          case "rwin":
+            AddUniqueVirtualKey(modifierKeys, VK_LWIN);
+            break;
+          default:
+            Keys parsedKey;
+            if (!Enum.TryParse(part, true, out parsedKey)) return false;
+            parsedKey &= Keys.KeyCode;
+            if (IsModifierKey(parsedKey) || parsedKey == Keys.None || keyCode != 0) return false;
+            keyCode = (ushort)parsedKey;
+            break;
+        }
+      }
+
+      return keyCode != 0;
+    }
+
+    static void AddUniqueVirtualKey(List<ushort> keys, int keyCode) {
+      ushort value = (ushort)keyCode;
+      if (!keys.Contains(value)) keys.Add(value);
+    }
+
+    static CancellationTokenSource _pipeCts;
+    static void getOmenKeyTask() {
+      _pipeCts = new CancellationTokenSource();
+      var token = _pipeCts.Token;
+      System.Threading.Tasks.Task.Run(() => {
+        while (!token.IsCancellationRequested) {
+          try {
+            using (var pipeServer = new NamedPipeServerStream("OmenSuperHubPipe", PipeDirection.In)) {
+              pipeServer.WaitForConnection();
+              using (var reader = new StreamReader(pipeServer)) {
+                string message = reader.ReadToEnd();
+                if (message.Contains("OmenKeyTriggered") && !omenKeyTriggered)
+                  omenKeyTriggered = true;
+              }
+            }
+          } catch (Exception) when (token.IsCancellationRequested) {
+            break;
+          } catch (Exception ex) {
+            Logger.Error("Pipe error: " + ex.Message);
+          }
+        }
+      }, token);
+    }
+  }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
-using System.IO.Pipes;
 using System.Linq;
 using System.Management;
 using System.Reflection;
@@ -52,7 +51,7 @@ namespace OmenSuperHub {
     static int alreadyRead = 0, alreadyReadCode = 1000;
     static readonly string[] PresetOrder = { "PresetExtreme", "PresetGpuPriority", "PresetLightUse", "PresetCustom1", "PresetCustom2", "PresetCustom3" };
     static string currentPreset = "PresetCustom1", presetCustom1Name = Strings.PresetCustom1, presetCustom2Name = Strings.PresetCustom2, presetCustom3Name = Strings.PresetCustom3;
-    static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = "default", omenKeyAppPath = "", omenKeyPresetCandidates = "", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
+    static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = OmenKeyActions.Default, omenKeyAppPath = "", omenKeyAppName = "", omenKeyShortcut = "", omenKeyPresetCandidates = "", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
     static volatile bool monitorFan = false;
     static bool skipCheckedUpdate = false; // action 内拦截时置 true，阻止 CreateMenuItem 覆盖勾选
     static bool powerOnline = SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online;
@@ -1208,201 +1207,6 @@ namespace OmenSuperHub {
       return (int)interpolated;
     }
 
-    static void HandleOmenKeyAction() {
-      if (!omenKeyTriggered) return;
-
-      omenKeyTriggered = false;
-      if (omenKey == "custom") {
-        ToggleFloatingBarByOmenKey();
-      } else if (omenKey == "app") {
-        LaunchOmenKeyApp();
-      } else if (omenKey == "preset") {
-        SwitchPresetByOmenKey();
-      }
-    }
-
-    static void ToggleFloatingBarByOmenKey() {
-      try {
-        using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\OmenSuperHub")) {
-          if (key != null) {
-            if ((string)key.GetValue("FloatingBar", "off") == "on") {
-              floatingBar = "off";
-              CloseFloatingForm();
-              UpdateCheckedState("floatingBarGroup", Strings.FloatingHide);
-            } else {
-              floatingBar = "on";
-              ShowFloatingForm();
-              UpdateCheckedState("floatingBarGroup", Strings.FloatingShow);
-            }
-            SaveConfig("FloatingBar");
-          }
-        }
-      } catch (Exception ex) {
-        Logger.Error($"Error restoring configuration: {ex.Message}");
-      }
-    }
-
-    static void LaunchOmenKeyApp() {
-      if (string.IsNullOrWhiteSpace(omenKeyAppPath) || !File.Exists(omenKeyAppPath)) {
-        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppNotFound, Strings.Hint, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-        return;
-      }
-
-      try {
-        string workingDirectory = Path.GetDirectoryName(omenKeyAppPath);
-        var startInfo = new ProcessStartInfo {
-          FileName = omenKeyAppPath,
-          UseShellExecute = true
-        };
-        if (!string.IsNullOrWhiteSpace(workingDirectory)) {
-          startInfo.WorkingDirectory = workingDirectory;
-        }
-        Process.Start(startInfo);
-      } catch (Exception ex) {
-        Logger.Error($"Failed to launch Omen key app: {ex.Message}");
-        MessageBox.Show(Application.OpenForms.OfType<HelpForm>().FirstOrDefault(), Strings.OmenKeyAppLaunchFailed(ex.Message), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-      }
-    }
-
-    static bool IsPresetAvailable(string presetKey) {
-      switch (presetKey) {
-        case "PresetExtreme":
-        case "PresetGpuPriority":
-        case "PresetLightUse":
-          return isCPUPowerControlSupported;
-        case "PresetCustom1":
-        case "PresetCustom2":
-        case "PresetCustom3":
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    static List<string> GetAvailablePresetKeys() {
-      return PresetOrder.Where(IsPresetAvailable).ToList();
-    }
-
-    static string GetDefaultOmenKeyPresetCandidates() {
-      return string.Join(";", GetAvailablePresetKeys());
-    }
-
-    static List<string> GetOmenKeyPresetCandidateKeys() {
-      var available = GetAvailablePresetKeys();
-      var candidates = (omenKeyPresetCandidates ?? "")
-          .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-          .Where(available.Contains)
-          .Distinct()
-          .OrderBy(key => Array.IndexOf(PresetOrder, key))
-          .ToList();
-
-      if (candidates.Count == 0) {
-        if (IsPresetAvailable(currentPreset)) {
-          candidates.Add(currentPreset);
-        } else if (available.Count > 0) {
-          candidates.Add(available[0]);
-        }
-      }
-
-      omenKeyPresetCandidates = string.Join(";", candidates);
-      return candidates;
-    }
-
-    static bool SetOmenKeyPresetCandidate(string presetKey, bool enabled) {
-      if (!IsPresetAvailable(presetKey)) return false;
-
-      var candidates = GetOmenKeyPresetCandidateKeys();
-      if (enabled) {
-        if (!candidates.Contains(presetKey))
-          candidates.Add(presetKey);
-      } else {
-        if (candidates.Count <= 1 && candidates.Contains(presetKey))
-          return false;
-        candidates.Remove(presetKey);
-      }
-
-      candidates = candidates
-          .Distinct()
-          .OrderBy(key => Array.IndexOf(PresetOrder, key))
-          .ToList();
-      omenKeyPresetCandidates = string.Join(";", candidates);
-      return true;
-    }
-
-    static void SwitchPresetByOmenKey() {
-      var candidates = GetOmenKeyPresetCandidateKeys();
-      if (candidates.Count == 0) return;
-
-      int currentIndex = candidates.IndexOf(currentPreset);
-      string targetPreset = candidates[(currentIndex + 1) % candidates.Count];
-      if (targetPreset != currentPreset) {
-        applyPresetLogic(targetPreset);
-      } else {
-        UpdateTrayIconText();
-      }
-
-      ShowOmenKeyPresetNotification();
-    }
-
-    static void ShowOmenKeyPresetNotification() {
-      if (trayIcon == null) return;
-
-      // 如果右键菜单当前处于展开状态，则直接拦截不通知
-      if (trayIcon.ContextMenuStrip != null && trayIcon.ContextMenuStrip.Visible) {
-        return;
-      }
-
-      trayIcon.BalloonTipTitle = Strings.OmenKeyPresetBalloonTitle;
-      trayIcon.BalloonTipText = Strings.OmenKeyPresetBalloonText(GetCurrentPresetDisplayName());
-      trayIcon.BalloonTipIcon = ToolTipIcon.Info;
-      trayIcon.ShowBalloonTip(3000);
-    }
-
-    static bool SelectOmenKeyApp() {
-      using (var dialog = new System.Windows.Forms.OpenFileDialog()) {
-        dialog.Title = Strings.OmenKeySelectApp;
-        dialog.Filter = Strings.OmenKeyAppFilter;
-        dialog.CheckFileExists = true;
-        dialog.Multiselect = false;
-        dialog.RestoreDirectory = true;
-
-        if (!string.IsNullOrWhiteSpace(omenKeyAppPath) && File.Exists(omenKeyAppPath)) {
-          dialog.InitialDirectory = Path.GetDirectoryName(omenKeyAppPath);
-          dialog.FileName = Path.GetFileName(omenKeyAppPath);
-        } else {
-          dialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        }
-
-        if (dialog.ShowDialog() != DialogResult.OK) return false;
-        omenKeyAppPath = dialog.FileName;
-        return true;
-      }
-    }
-
-    static CancellationTokenSource _pipeCts;
-    static void getOmenKeyTask() {
-      _pipeCts = new CancellationTokenSource();
-      var token = _pipeCts.Token;
-      System.Threading.Tasks.Task.Run(() => {
-        while (!token.IsCancellationRequested) {
-          try {
-            using (var pipeServer = new NamedPipeServerStream("OmenSuperHubPipe", PipeDirection.In)) {
-              pipeServer.WaitForConnection();    // 若需要支持取消，可用异步版本
-              using (var reader = new StreamReader(pipeServer)) {
-                string message = reader.ReadToEnd();
-                if (message.Contains("OmenKeyTriggered") && !omenKeyTriggered)
-                  omenKeyTriggered = true;
-              }
-            }
-          } catch (Exception) when (token.IsCancellationRequested) {
-            break;
-          } catch (Exception ex) {
-            Logger.Error("Pipe error: " + ex.Message);
-          }
-        }
-      }, token);
-    }
-
     // 根据 floatingBarScreen 获取目标显示器，找不到时回退主屏幕
     static Screen GetFloatingScreen() {
       if (!string.IsNullOrEmpty(floatingBarScreen)) {
@@ -1508,7 +1312,7 @@ namespace OmenSuperHub {
 
     static void Exit() {
       _pipeCts?.Cancel();
-      if (omenKey == "custom" || omenKey == "app" || omenKey == "preset") {
+      if (OmenKeyActions.UsesPipe(omenKey)) {
         OmenKeyOff();
       }
       tooltipUpdateTimer.Stop(); // 停止定时器

--- a/Strings.cs
+++ b/Strings.cs
@@ -48,6 +48,9 @@
     public static string OtherSettings => T("其他设置", "其他設定", "Settings");
     public static string Help => T("帮助", "說明", "Help");
     public static string Exit => T("退出", "結束", "Exit");
+    public static string OK => T("确定", "確定", "OK");
+    public static string Cancel => T("取消", "取消", "Cancel");
+    public static string Clear => T("清除", "清除", "Clear");
 
     // ─────────────────────────────────────────────────────────────────────────
     // 预设菜单
@@ -471,10 +474,15 @@
         $"目前預設：{name}",
         $"Current preset: {name}");
     public static string OmenKeyLaunchApp => T("打开应用", "開啟應用程式", "Open App");
+    public static string OmenKeyShortcut => T("模拟按键", "模擬按鍵", "Simulate Shortcut");
     public static string OmenKeySelectApp => T("选择应用", "選擇應用程式", "Select App");
+    public static string OmenKeySelectDesktopApp => T("选择桌面应用", "選擇桌面應用程式", "Select Desktop App");
+    public static string OmenKeySelectUwpApp => T("选择 UWP 应用", "選擇 UWP 應用程式", "Select UWP App");
     public static string OmenKeyClearApp => T("清除应用绑定", "清除應用程式綁定", "Clear App Binding");
     public static string OmenKeyCurrentApp => T("当前应用", "目前應用程式", "Current App");
+    public static string OmenKeyCurrentShortcut => T("当前模拟按键", "目前模擬按鍵", "Current Shortcut");
     public static string OmenKeyNoAppSelected => T("未选择", "未選擇", "Not Selected");
+    public static string OmenKeyNoShortcutSelected => T("未设置", "未設定", "Not Set");
     public static string OmenKeyAppFilter => T(
         "应用程序和快捷方式|*.exe;*.lnk;*.bat;*.cmd|所有文件|*.*",
         "應用程式和捷徑|*.exe;*.lnk;*.bat;*.cmd|所有檔案|*.*",
@@ -487,6 +495,29 @@
         $"打开应用失败：{msg}",
         $"開啟應用程式失敗：{msg}",
         $"Failed to open app: {msg}");
+    public static string OmenKeyUwpAppName => T("应用名称", "應用程式名稱", "App Name");
+    public static string OmenKeyUwpNoApps => T(
+        "没有找到可启动的 UWP 应用。",
+        "找不到可啟動的 UWP 應用程式。",
+        "No launchable UWP apps were found.");
+    public static string OmenKeyUwpLoadFailed(string msg) => T(
+        $"读取 UWP 应用列表失败：{msg}",
+        $"讀取 UWP 應用程式清單失敗：{msg}",
+        $"Failed to load UWP app list: {msg}");
+    public static string OmenKeySetShortcut => T("设置模拟按键", "設定模擬按鍵", "Set Simulated Shortcut");
+    public static string OmenKeyShortcutCapturePrompt => T(
+        "请按下要模拟的按键或组合键。",
+        "請按下要模擬的按鍵或組合鍵。",
+        "Press the key or shortcut to simulate.");
+    public static string OmenKeyClearShortcut => T("清除模拟按键", "清除模擬按鍵", "Clear Simulated Shortcut");
+    public static string OmenKeyShortcutNotSet => T(
+        "未设置要模拟的按键。",
+        "未設定要模擬的按鍵。",
+        "No simulated shortcut has been set.");
+    public static string OmenKeyShortcutSendFailed(int error) => T(
+        $"模拟按键发送失败，错误码：{error}",
+        $"模擬按鍵傳送失敗，錯誤碼：{error}",
+        $"Failed to send simulated shortcut. Error code: {error}");
     public static string OmenKeyNone => T("取消绑定", "取消綁定", "Unbound");
 
     // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- 支持 OMEN 键绑定并启动 UWP 应用
- 支持 OMEN 键模拟普通按键或组合键
- 将 OMEN 键相关逻辑拆分到 `Program.OmenKey.cs`
- 统一 OMEN 键动作常量和切换逻辑，减少菜单、配置、硬件触发代码中的重复分发

## Details

- 新增 `OmenKeyActions`，统一管理 `default`、`custom`、`app`、`shortcut`、`preset`、`none`
- 新增 `ApplyOmenKeyAction()` / `RestoreOmenKeyAction()`，集中处理 OMEN 键动作切换、WMI 注册和配置恢复
- UWP 应用通过 `Get-StartApps` 枚举，并使用 `shell:AppsFolder\AUMID` 启动
- 模拟按键通过 Win32 `SendInput` 实现，支持 Ctrl / Shift / Alt / Win 组合键
- 保留旧注册表字段兼容性，并新增：
  - `OmenKeyAppName`
  - `OmenKeyShortcut`

## Test

- [x] Debug x64 build passed
- [x] Release x64 build passed
- [x] `git diff --check` passed