### PR TITLE
添加CPU0，GPU频率显示

### DIFF
--- a/FloatingForm.cs
+++ b/FloatingForm.cs
@@ -1,11 +1,23 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace OmenSuperHub {
   public partial class FloatingForm : Form {
+    private const int ContentPadding = 10;
+    private const int ScreenMargin = 10;
+
     private PictureBox displayPictureBox;
+
+    private sealed class DisplayLine {
+      public string Title;
+      public string Value;
+      public float TitleWidth;
+      public float ValueWidth;
+    }
 
     public FloatingForm(string text, int textSize, string loc, Screen screen = null) {
       this.FormBorderStyle = FormBorderStyle.None;
@@ -16,80 +28,136 @@ namespace OmenSuperHub {
       displayPictureBox = new PictureBox();
       displayPictureBox.BackColor = Color.Transparent;
       displayPictureBox.SizeMode = PictureBoxSizeMode.AutoSize;
-
-      ApplySupersampling(text, textSize);
-
-      if (loc == "left") {
-        SetPositionTopLeft(screen);
-      } else {
-        SetPositionTopRight(textSize, screen);
-      }
-
       this.Controls.Add(displayPictureBox);
+      this.HandleCreated += (s, e) => RenderCurrentImage();
+
+      ApplySupersampling(text, textSize, screen);
       AdjustFormSize();
+      SetAnchoredPosition(loc, screen);
     }
 
-    private void ApplySupersampling(string text, int textSize) {
+    private void ApplySupersampling(string text, int textSize, Screen screen) {
       if (string.IsNullOrEmpty(text) || textSize <= 0)
         return;
 
-      string[] lines = text.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+      var workingArea = (screen ?? Screen.PrimaryScreen).WorkingArea;
+      int maxBitmapWidth = Math.Max(1, workingArea.Width - ScreenMargin * 2);
+      float maxContentWidth = Math.Max(1, maxBitmapWidth - ContentPadding * 2);
+      Bitmap newBitmap = null;
 
-      Bitmap newBitmap;
       try {
-        newBitmap = new Bitmap(700, 300);
-      } catch (ArgumentException ex) {
-        System.Diagnostics.Debug.WriteLine($"Bitmap 创建失败: {ex.Message}");
-        return;
-      }
+        using (var measureBitmap = new Bitmap(1, 1, PixelFormat.Format32bppArgb))
+        using (var measureGraphics = Graphics.FromImage(measureBitmap))
+        using (var font = new Font("Calibri", textSize, FontStyle.Bold, GraphicsUnit.World))
+        using (var format = CreateTextFormat()) {
+          var lines = BuildDisplayLines(text, font, measureGraphics, format, maxContentWidth);
+          float lineHeight = (float)Math.Ceiling(font.GetHeight(measureGraphics));
+          float widestLine = 1;
+          foreach (var line in lines)
+            widestLine = Math.Max(widestLine, line.TitleWidth + line.ValueWidth);
 
-      using (Graphics graphics = Graphics.FromImage(newBitmap)) {
-        graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
-        graphics.Clear(Color.Transparent);
+          int bitmapWidth = Math.Min(maxBitmapWidth,
+            Math.Max(1, (int)Math.Ceiling(widestLine) + ContentPadding * 2));
+          int bitmapHeight = Math.Max(1,
+            (int)Math.Ceiling(lineHeight * lines.Count) + ContentPadding * 2);
 
-        using (Font font = new Font("Calibri", textSize, FontStyle.Bold, GraphicsUnit.World)) {
-          PointF point = new PointF(0, 0);
-          for (int i = 0; i < lines.Length; i++) {
-            string[] parts = lines[i].Split(':');
-            if (parts.Length > 1) {
-              string title = parts[0].Trim() + ":";
-              string value = " " + parts[1].Trim();
-              Color titleColor = GetColorForTitle(parts[0].Trim());
+          newBitmap = new Bitmap(bitmapWidth, bitmapHeight, PixelFormat.Format32bppArgb);
+          using (Graphics graphics = Graphics.FromImage(newBitmap)) {
+            graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            // graphics.Clear(Color.FromArgb(180, 0, 0, 0));
+            //透明
+            graphics.Clear(Color.Transparent);
 
-              // 单独绘制标题
-              string titleWithNewlines = title;
-              for (int j = 0; j < i; j++)
-                titleWithNewlines = '\n' + titleWithNewlines;
-              SizeF titleSize = graphics.MeasureString(titleWithNewlines, font);
-              using (Brush brush = new SolidBrush(titleColor))
-                graphics.DrawString(titleWithNewlines, font, brush, point);
+            float y = ContentPadding;
+            using (Brush valueBrush = new SolidBrush(Color.FromArgb(255, 128, 0))) {
+              foreach (var line in lines) {
+                float x = ContentPadding;
+                if (!string.IsNullOrEmpty(line.Title)) {
+                  string titleKey = line.Title.TrimEnd(':').Trim();
+                  using (Brush titleBrush = new SolidBrush(GetColorForTitle(titleKey)))
+                    graphics.DrawString(line.Title, font, titleBrush, new PointF(x, y), format);
+                  x += line.TitleWidth;
+                }
 
-              // 单独绘制值，紧接标题之后
-              string valueWithNewlines = value;
-              for (int j = 0; j < i; j++)
-                valueWithNewlines = '\n' + valueWithNewlines;
-              using (Brush brush = new SolidBrush(Color.FromArgb(255, 128, 0)))
-                graphics.DrawString(valueWithNewlines, font, brush, new PointF(titleSize.Width, point.Y));
-            } else {
-              string lineWithNewlines = lines[i];
-              for (int j = 0; j < i; j++)
-                lineWithNewlines = '\n' + lineWithNewlines;
-              using (Brush brush = new SolidBrush(Color.FromArgb(255, 128, 0)))
-                graphics.DrawString(lineWithNewlines, font, brush, point);
+                graphics.DrawString(line.Value, font, valueBrush, new PointF(x, y), format);
+                y += lineHeight;
+              }
             }
           }
         }
+      } catch (ArgumentException ex) {
+        newBitmap?.Dispose();
+        System.Diagnostics.Debug.WriteLine($"Bitmap 创建失败: {ex.Message}");
+        return;
       }
 
       var oldImage = displayPictureBox.Image;
       displayPictureBox.Image = newBitmap;
       displayPictureBox.Size = newBitmap.Size;
       oldImage?.Dispose();
+    }
 
-      if (IsHandleCreated)
-        RenderLayered(newBitmap);
-      else
-        this.HandleCreated += (s, e) => RenderLayered(newBitmap);
+    private static StringFormat CreateTextFormat() {
+      var format = (StringFormat)StringFormat.GenericTypographic.Clone();
+      format.FormatFlags |= StringFormatFlags.MeasureTrailingSpaces;
+      return format;
+    }
+
+    private static float MeasureText(Graphics graphics, string text, Font font, StringFormat format) {
+      if (string.IsNullOrEmpty(text)) return 0;
+      return graphics.MeasureString(text, font, int.MaxValue, format).Width;
+    }
+
+    private static List<DisplayLine> BuildDisplayLines(string text, Font font,
+        Graphics graphics, StringFormat format, float maxContentWidth) {
+      var result = new List<DisplayLine>();
+      string[] sourceLines = text.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+      foreach (string sourceLine in sourceLines) {
+        int separatorIndex = sourceLine.IndexOf(':');
+        string title = separatorIndex >= 0 ? sourceLine.Substring(0, separatorIndex).Trim() + ":" : "";
+        string value = separatorIndex >= 0 ? sourceLine.Substring(separatorIndex + 1).Trim() : sourceLine.Trim();
+        string valuePrefix = title.Length > 0 ? " " : "";
+        float titleWidth = MeasureText(graphics, title, font, format);
+        string[] segments = value.Split(new[] { ',' }, StringSplitOptions.None);
+        string current = "";
+        bool firstOutputLine = true;
+
+        for (int i = 0; i < segments.Length; i++) {
+          string segment = segments[i].Trim();
+          if (i < segments.Length - 1) segment += ",";
+          string candidate = current.Length == 0 ? segment : current + " " + segment;
+          float prefixWidth = firstOutputLine ? titleWidth : 0;
+          float candidateWidth = MeasureText(graphics, valuePrefix + candidate, font, format);
+
+          if (current.Length > 0 && prefixWidth + candidateWidth > maxContentWidth) {
+            AddDisplayLine(result, firstOutputLine ? title : "", valuePrefix + current,
+              font, graphics, format);
+            firstOutputLine = false;
+            valuePrefix = "";
+            current = segment;
+          } else {
+            current = candidate;
+          }
+        }
+
+        AddDisplayLine(result, firstOutputLine ? title : "", valuePrefix + current,
+          font, graphics, format);
+      }
+
+      if (result.Count == 0)
+        AddDisplayLine(result, "", " ", font, graphics, format);
+      return result;
+    }
+
+    private static void AddDisplayLine(List<DisplayLine> lines, string title, string value,
+        Font font, Graphics graphics, StringFormat format) {
+      lines.Add(new DisplayLine {
+        Title = title,
+        Value = value,
+        TitleWidth = MeasureText(graphics, title, font, format),
+        ValueWidth = MeasureText(graphics, value, font, format)
+      });
     }
 
     private Color GetColorForTitle(string title) {
@@ -107,19 +175,15 @@ namespace OmenSuperHub {
         return;
       }
       if (textSize <= 0) return;
-      ApplySupersampling(text, textSize);
+      ApplySupersampling(text, textSize, screen);
       AdjustFormSize();
-      if (loc == "left") {
-        SetPositionTopLeft(screen);
-      } else {
-        SetPositionTopRight(textSize, screen);
-      }
+      SetAnchoredPosition(loc, screen);
+      RenderCurrentImage();
     }
 
     private void AdjustFormSize() {
-      // 根据Label的大小动态调整窗体大小
-      this.Size = new Size(displayPictureBox.Width + 20, displayPictureBox.Height + 20);
-      displayPictureBox.Location = new Point(10, 10);
+      this.Size = displayPictureBox.Size;
+      displayPictureBox.Location = Point.Empty;
     }
 
     protected override void OnMove(EventArgs e) {
@@ -139,16 +203,30 @@ namespace OmenSuperHub {
     }
 
     public void SetPositionTopLeft(Screen screen = null) {
-      var wa = (screen ?? Screen.PrimaryScreen).WorkingArea;
-      this.Location = new Point(wa.Left + 10, wa.Top + 10);
+      SetAnchoredPosition("left", screen);
     }
 
     public void SetPositionTopRight(int textSize, Screen screen = null) {
+      SetAnchoredPosition("right", screen);
+    }
+
+    private void SetAnchoredPosition(string loc, Screen screen) {
       var wa = (screen ?? Screen.PrimaryScreen).WorkingArea;
-      this.Location = new Point(
-        wa.Left + (int)(wa.Width - textSize * wa.Width / 256 + 10),
-        wa.Top + 10
-      );
+      int desiredX = loc == "left"
+        ? wa.Left + ScreenMargin
+        : wa.Right - this.Width - ScreenMargin;
+      int desiredY = wa.Top + ScreenMargin;
+      int maxX = wa.Right - this.Width;
+      int maxY = wa.Bottom - this.Height;
+
+      int x = maxX < wa.Left ? wa.Left : Math.Max(wa.Left, Math.Min(desiredX, maxX));
+      int y = maxY < wa.Top ? wa.Top : Math.Max(wa.Top, Math.Min(desiredY, maxY));
+      this.Location = new Point(x, y);
+    }
+
+    private void RenderCurrentImage() {
+      if (displayPictureBox.Image is Bitmap bitmap && IsHandleCreated)
+        RenderLayered(bitmap);
     }
 
     private void RenderLayered(Bitmap bitmap) {

--- a/LibreHardwareMonitor/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitor/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -18,6 +18,8 @@ internal sealed class Amd17Cpu : AmdCpu
     private readonly RyzenSMU _smu;
     private readonly AmdFamily17 _pawnModule;
 
+    private bool IsZen5 => _family == 0x1a;
+
     public Amd17Cpu(int processorIndex, CpuId[][] cpuId, ISettings settings) : base(processorIndex, cpuId, settings)
     {
         _pawnModule = new AmdFamily17();
@@ -163,6 +165,12 @@ internal sealed class Amd17Cpu : AmdCpu
                 Mutexes.ReleasePciBus();
             }
 
+            foreach (NumaNode node in Nodes)
+            {
+                foreach (Core core in node.Cores)
+                    core.UpdateSensors();
+            }
+
             ThreadAffinity.Set(previousAffinity);
         }
 
@@ -225,15 +233,54 @@ internal sealed class Amd17Cpu : AmdCpu
 
     private class Core
     {
+        private readonly Sensor _clock;
+        private readonly Amd17Cpu _cpu;
+
         public Core(Amd17Cpu cpu, int id)
         {
             CoreId = id;
+            _cpu = cpu;
+            _clock = new Sensor("CPU Core #" + CoreId, _cpu._sensorTypeIndex[SensorType.Clock]++, SensorType.Clock, _cpu, _cpu._settings);
+            _cpu.ActivateSensor(_clock);
             _ = cpu; // 保留参数以维持 AppendThread 调用链（Processor.AppendThread 需要构造 Core）
         }
 
         public int CoreId { get; }
 
         public List<CpuId> Threads { get; } = new();
+
+        public void UpdateSensors()
+        {
+            CpuId thread = Threads.FirstOrDefault();
+            if (thread == null)
+                return;
+
+            GroupAffinity previousAffinity = ThreadAffinity.Set(thread.Affinity);
+            try
+            {
+                if (!_cpu._pawnModule.ReadMsr(MSR_HARDWARE_PSTATE_STATUS, out uint eax, out _))
+                    return;
+
+                if (_cpu.IsZen5)
+                {
+                    uint cpuFid = eax & 0xFFF;
+                    _clock.Value = cpuFid * 5;
+                }
+                else
+                {
+                    uint cpuDfsId = (eax >> 8) & 0x3F;
+                    uint cpuFid = eax & 0xFF;
+                    if (cpuDfsId == 0)
+                        return;
+
+                    _clock.Value = (float)(cpuFid / (double)cpuDfsId * 200.0);
+                }
+            }
+            finally
+            {
+                ThreadAffinity.Set(previousAffinity);
+            }
+        }
 
         public void AppendThread(CpuId cpuId)
         {
@@ -246,6 +293,7 @@ internal sealed class Amd17Cpu : AmdCpu
     private const uint F17H_M01H_THM_TCON_CUR_TMP = 0x00059800;
     private const uint F17H_TEMP_RANGE_SEL_MASK = 0x80000;
     private const uint F17H_TEMP_TJ_SEL_MASK = 0x30000;
+    private const uint MSR_HARDWARE_PSTATE_STATUS = 0xC0010293;
     private const uint MSR_PKG_ENERGY_STAT = 0xC001029B;
     private const uint MSR_PWR_UNIT = 0xC0010299;
     // ReSharper restore InconsistentNaming

--- a/LibreHardwareMonitor/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitor/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -18,9 +18,12 @@ internal sealed class IntelCpu : GenericCpu
     private readonly uint[] _lastEnergyConsumed;
     private readonly DateTime[] _lastEnergyTime;
 
+    private readonly Sensor _busClock;
+    private readonly Sensor[] _coreClocks;
     private readonly MicroArchitecture _microArchitecture;
     private readonly Sensor _packageTemperature;
     private readonly Sensor[] _powerSensors;
+    private readonly double _timeStampCounterMultiplier;
 
     private readonly IntelMsr _pawnModule;
 
@@ -281,6 +284,47 @@ internal sealed class IntelCpu : GenericCpu
                 break;
         }
 
+        switch (_microArchitecture)
+        {
+            case MicroArchitecture.Atom:
+            case MicroArchitecture.Core:
+            case MicroArchitecture.NetBurst:
+                if (_pawnModule.ReadMsr(IA32_PERF_STATUS, out uint _, out uint edx))
+                    _timeStampCounterMultiplier = ((edx >> 8) & 0x1F) + (0.5 * ((edx >> 14) & 1));
+                break;
+            case MicroArchitecture.Airmont:
+            case MicroArchitecture.AlderLake:
+            case MicroArchitecture.ArrowLake:
+            case MicroArchitecture.Broadwell:
+            case MicroArchitecture.CannonLake:
+            case MicroArchitecture.CometLake:
+            case MicroArchitecture.Goldmont:
+            case MicroArchitecture.GoldmontPlus:
+            case MicroArchitecture.Haswell:
+            case MicroArchitecture.IceLake:
+            case MicroArchitecture.IvyBridge:
+            case MicroArchitecture.JasperLake:
+            case MicroArchitecture.KabyLake:
+            case MicroArchitecture.LunarLake:
+            case MicroArchitecture.MeteorLake:
+            case MicroArchitecture.PantherLake:
+            case MicroArchitecture.RaptorLake:
+            case MicroArchitecture.RocketLake:
+            case MicroArchitecture.SandyBridge:
+            case MicroArchitecture.Silvermont:
+            case MicroArchitecture.Skylake:
+            case MicroArchitecture.TigerLake:
+            case MicroArchitecture.SapphireRapids:
+            case MicroArchitecture.ElkhartLake:
+            case MicroArchitecture.Tremont:
+                if (_pawnModule.ReadMsr(MSR_PLATFORM_INFO, out eax, out uint _))
+                    _timeStampCounterMultiplier = (eax >> 8) & 0xFF;
+                break;
+            default:
+                _timeStampCounterMultiplier = 0;
+                break;
+        }
+
         // check if processor supports a digital thermal sensor at package level
         if (cpuId[0][0].Data.GetLength(0) > 6 && (cpuId[0][0].Data[6, 0] & 0x40) != 0 && _microArchitecture != MicroArchitecture.Unknown)
         {
@@ -295,6 +339,15 @@ internal sealed class IntelCpu : GenericCpu
                                              settings);
 
             ActivateSensor(_packageTemperature);
+        }
+
+        _busClock = new Sensor("Bus Speed", 0, SensorType.Clock, this, settings);
+        _coreClocks = new Sensor[_coreCount];
+        for (int i = 0; i < _coreClocks.Length; i++)
+        {
+            _coreClocks[i] = new Sensor(CoreString(i), i + 1, SensorType.Clock, this, settings);
+            if (HasTimeStampCounter && _timeStampCounterMultiplier > 0 && _microArchitecture != MicroArchitecture.Unknown)
+                ActivateSensor(_coreClocks[i]);
         }
 
         if (_microArchitecture is MicroArchitecture.Airmont or
@@ -427,6 +480,63 @@ internal sealed class IntelCpu : GenericCpu
             else
             {
                 _packageTemperature.Value = null;
+            }
+        }
+
+        if (HasTimeStampCounter && _timeStampCounterMultiplier > 0 && _coreClocks != null)
+        {
+            double newBusClock = TimeStampCounterFrequency / _timeStampCounterMultiplier;
+            for (int i = 0; i < _coreClocks.Length; i++)
+            {
+                if (_pawnModule.ReadMsr(IA32_PERF_STATUS, out eax, out _, _cpuId[i][0].Affinity))
+                {
+                    switch (_microArchitecture)
+                    {
+                        case MicroArchitecture.Nehalem:
+                            _coreClocks[i].Value = (float)((eax & 0xFF) * newBusClock);
+                            break;
+                        case MicroArchitecture.Airmont:
+                        case MicroArchitecture.AlderLake:
+                        case MicroArchitecture.ArrowLake:
+                        case MicroArchitecture.Broadwell:
+                        case MicroArchitecture.CannonLake:
+                        case MicroArchitecture.CometLake:
+                        case MicroArchitecture.Goldmont:
+                        case MicroArchitecture.GoldmontPlus:
+                        case MicroArchitecture.Haswell:
+                        case MicroArchitecture.IceLake:
+                        case MicroArchitecture.IvyBridge:
+                        case MicroArchitecture.JasperLake:
+                        case MicroArchitecture.KabyLake:
+                        case MicroArchitecture.LunarLake:
+                        case MicroArchitecture.MeteorLake:
+                        case MicroArchitecture.PantherLake:
+                        case MicroArchitecture.RaptorLake:
+                        case MicroArchitecture.RocketLake:
+                        case MicroArchitecture.SandyBridge:
+                        case MicroArchitecture.Silvermont:
+                        case MicroArchitecture.Skylake:
+                        case MicroArchitecture.TigerLake:
+                        case MicroArchitecture.SapphireRapids:
+                        case MicroArchitecture.ElkhartLake:
+                        case MicroArchitecture.Tremont:
+                            _coreClocks[i].Value = (float)(((eax >> 8) & 0xFF) * newBusClock);
+                            break;
+                        default:
+                            _coreClocks[i].Value = (float)((((eax >> 8) & 0x1F) + (0.5 * ((eax >> 14) & 1))) * newBusClock);
+                            break;
+                    }
+                }
+                else
+                {
+                    _coreClocks[i].Value = (float)TimeStampCounterFrequency;
+                }
+            }
+
+            if (newBusClock > 0)
+            {
+                _busClock.Value = (float)newBusClock;
+                ActivateSensor(_busClock);
             }
         }
 

--- a/LibreHardwareMonitor/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitor/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -9,6 +9,7 @@ internal sealed class NvidiaGpu : GenericGpu
 {
     private readonly NvApi.NvPhysicalGpuHandle _handle;
     private readonly NvidiaML.NvmlDevice? _nvmlDevice;
+    private readonly Sensor _coreClock;
     private readonly Sensor _powerUsage;
     private readonly Sensor _temperature;
     private bool _firstUpdate = true;
@@ -21,6 +22,13 @@ internal sealed class NvidiaGpu : GenericGpu
         // 温度传感器
         _temperature = new Sensor("GPU Core", 0, SensorType.Temperature, this, settings);
         ActivateSensor(_temperature);
+
+        // 频率传感器 (NVAPI)
+        if (NvApi.NvAPI_GPU_GetAllClockFrequencies != null)
+        {
+            _coreClock = new Sensor("GPU Core", 0, SensorType.Clock, this, settings);
+            ActivateSensor(_coreClock);
+        }
 
         // 功率传感器 (NVML)
         if (NvidiaML.IsAvailable || NvidiaML.Initialize())
@@ -69,6 +77,8 @@ internal sealed class NvidiaGpu : GenericGpu
                 _temperature.Value = null;
                 if (_powerUsage != null)
                     _powerUsage.Value = null;
+                if (_coreClock != null)
+                    _coreClock.Value = null;
                 return;
             }
             else
@@ -86,6 +96,15 @@ internal sealed class NvidiaGpu : GenericGpu
                 _temperature.Value = thermalSettings.Sensor[0].CurrentTemp;
             }
 
+            // 频率
+            if (_coreClock != null)
+            {
+                if (TryGetCoreClock(out float coreClock))
+                    _coreClock.Value = coreClock;
+                else
+                    _coreClock.Value = null;
+            }
+
             // 功率
             if (_nvmlDevice.HasValue)
             {
@@ -101,6 +120,38 @@ internal sealed class NvidiaGpu : GenericGpu
         {
             Debug.WriteLine($"{nameof(NvidiaGpu)}.{nameof(Update)} failed for {Name} ({Identifier}): {e}");
         }
+    }
+
+    private bool TryGetCoreClock(out float coreClock)
+    {
+        coreClock = 0f;
+        if (NvApi.NvAPI_GPU_GetAllClockFrequencies == null)
+            return false;
+
+        for (int version = 1; version <= 3; version++)
+        {
+            var clockFrequencies = new NvApi.NvGpuClockFrequencies
+            {
+                Version = (uint)NvApi.MAKE_NVAPI_VERSION<NvApi.NvGpuClockFrequencies>(version),
+                Clocks = new NvApi.NvGpuClockFrequenciesDomain[NvApi.MAX_GPU_PUBLIC_CLOCKS]
+            };
+
+            if (NvApi.NvAPI_GPU_GetAllClockFrequencies(_handle, ref clockFrequencies) != NvApi.NvStatus.OK)
+                continue;
+
+            int graphicsClockIndex = (int)NvApi.NvGpuPublicClockId.Graphics;
+            if (clockFrequencies.Clocks.Length <= graphicsClockIndex)
+                continue;
+
+            var graphicsClock = clockFrequencies.Clocks[graphicsClockIndex];
+            if (!graphicsClock.IsPresent || graphicsClock.Frequency == 0)
+                continue;
+
+            coreClock = graphicsClock.Frequency / 1000f;
+            return true;
+        }
+
+        return false;
     }
 
     private static string GetName(NvApi.NvPhysicalGpuHandle handle)

--- a/Program.Config.cs
+++ b/Program.Config.cs
@@ -663,9 +663,24 @@ namespace OmenSuperHub {
       return resultSpeed;
     }
 
+    static bool IsBuiltInPreset(string presetKey) {
+      return presetKey == "PresetExtreme" || presetKey == "PresetGpuPriority" || presetKey == "PresetLightUse";
+    }
+
+    static bool IsMonitorMetricConfig(string configName) {
+      return configName == "ShowCPUTemp" || configName == "ShowCPUPower" || configName == "ShowCPUFrequency" ||
+             configName == "ShowGPUTemp" || configName == "ShowGPUPower" || configName == "ShowGPUFrequency";
+    }
+
     static void SaveConfig(string configName = null) {
       // 内置预设下调整设置时，不再强制切换到 Custom1，直接保存注册表（不关联任何预设子键）
       try {
+        // 六项监控显示开关在自定义预设下只写入当前预设，避免污染内置预设的全局值。
+        if (!IsBuiltInPreset(currentPreset) && IsMonitorMetricConfig(configName)) {
+          SavePresetToRegistry(currentPreset);
+          return;
+        }
+
         using (RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\OmenSuperHub")) {
           if (key != null) {
             if (configName == null) {
@@ -701,12 +716,14 @@ namespace OmenSuperHub {
               key.SetValue("MonitorFan", monitorFan);
               key.SetValue("MonitorRefreshRate", monitorRefreshRate);
               key.SetValue("TempDisplayMode", tempDisplayMode);
-              key.SetValue("ShowCPUTemp", showCPUTemp);
-              key.SetValue("ShowCPUPower", showCPUPower);
-              key.SetValue("ShowCPUFrequency", showCPUFrequency);
-              key.SetValue("ShowGPUTemp", showGPUTemp);
-              key.SetValue("ShowGPUPower", showGPUPower);
-              key.SetValue("ShowGPUFrequency", showGPUFrequency);
+              if (IsBuiltInPreset(currentPreset)) {
+                key.SetValue("ShowCPUTemp", showCPUTemp);
+                key.SetValue("ShowCPUPower", showCPUPower);
+                key.SetValue("ShowCPUFrequency", showCPUFrequency);
+                key.SetValue("ShowGPUTemp", showGPUTemp);
+                key.SetValue("ShowGPUPower", showGPUPower);
+                key.SetValue("ShowGPUFrequency", showGPUFrequency);
+              }
               key.SetValue("FloatingBarLoc", floatingBarLoc);
               key.SetValue("FloatingBar", floatingBar);
               key.SetValue("FloatingBarScreen", floatingBarScreen);
@@ -926,6 +943,58 @@ namespace OmenSuperHub {
       } catch (Exception ex) {
         Logger.Error($"LoadPresetFields({presetKey}): {ex.Message}");
       }
+    }
+
+    static void LoadMonitorMetricSettings(string presetKey) {
+      bool globalShowCPUTemp = true;
+      bool globalShowCPUPower = true;
+      bool globalShowCPUFrequency = true;
+      bool globalShowGPUTemp = true;
+      bool globalShowGPUPower = true;
+      bool globalShowGPUFrequency = true;
+
+      try {
+        using (RegistryKey globalKey = Registry.CurrentUser.OpenSubKey(@"Software\OmenSuperHub")) {
+          if (globalKey != null) {
+            globalShowCPUTemp = Convert.ToBoolean(globalKey.GetValue("ShowCPUTemp", true));
+            globalShowCPUPower = Convert.ToBoolean(globalKey.GetValue("ShowCPUPower", true));
+            globalShowCPUFrequency = Convert.ToBoolean(globalKey.GetValue("ShowCPUFrequency", true));
+            globalShowGPUTemp = Convert.ToBoolean(globalKey.GetValue("ShowGPUTemp", true));
+            globalShowGPUPower = Convert.ToBoolean(globalKey.GetValue("ShowGPUPower", true));
+            globalShowGPUFrequency = Convert.ToBoolean(globalKey.GetValue("ShowGPUFrequency", true));
+          }
+        }
+
+        if (IsBuiltInPreset(presetKey)) {
+          showCPUTemp = globalShowCPUTemp;
+          showCPUPower = globalShowCPUPower;
+          showCPUFrequency = globalShowCPUFrequency;
+          showGPUTemp = globalShowGPUTemp;
+          showGPUPower = globalShowGPUPower;
+          showGPUFrequency = globalShowGPUFrequency;
+          return;
+        }
+
+        using (RegistryKey presetKeyHandle = Registry.CurrentUser.OpenSubKey($@"Software\OmenSuperHub\{presetKey}")) {
+          showCPUTemp = Convert.ToBoolean(presetKeyHandle?.GetValue("ShowCPUTemp", globalShowCPUTemp) ?? globalShowCPUTemp);
+          showCPUPower = Convert.ToBoolean(presetKeyHandle?.GetValue("ShowCPUPower", globalShowCPUPower) ?? globalShowCPUPower);
+          showCPUFrequency = Convert.ToBoolean(presetKeyHandle?.GetValue("ShowCPUFrequency", globalShowCPUFrequency) ?? globalShowCPUFrequency);
+          showGPUTemp = Convert.ToBoolean(presetKeyHandle?.GetValue("ShowGPUTemp", globalShowGPUTemp) ?? globalShowGPUTemp);
+          showGPUPower = Convert.ToBoolean(presetKeyHandle?.GetValue("ShowGPUPower", globalShowGPUPower) ?? globalShowGPUPower);
+          showGPUFrequency = Convert.ToBoolean(presetKeyHandle?.GetValue("ShowGPUFrequency", globalShowGPUFrequency) ?? globalShowGPUFrequency);
+        }
+      } catch (Exception ex) {
+        Logger.Error($"LoadMonitorMetricSettings({presetKey}): {ex.Message}");
+      }
+    }
+
+    static void UpdateMonitorMetricCheckedStates() {
+      SetMenuItemChecked("showCPUTempGroup", Strings.MonitorCpuTempLabel, showCPUTemp);
+      SetMenuItemChecked("showCPUPowerGroup", Strings.MonitorCpuPowerLabel, showCPUPower);
+      SetMenuItemChecked("showCPUFrequencyGroup", Strings.MonitorCpuFrequencyLabel, showCPUFrequency);
+      SetMenuItemChecked("showGPUTempGroup", Strings.MonitorGpuTempLabel, showGPUTemp);
+      SetMenuItemChecked("showGPUPowerGroup", Strings.MonitorGpuPowerLabel, showGPUPower);
+      SetMenuItemChecked("showGPUFrequencyGroup", Strings.MonitorGpuFrequencyLabel, showGPUFrequency);
     }
 
     /// <summary>
@@ -1188,7 +1257,12 @@ namespace OmenSuperHub {
         LoadPresetFields(targetPreset);
       }
 
-      SaveConfig();                                          // 持久化到注册表
+      LoadMonitorMetricSettings(targetPreset);
+      UpdateMonitorMetricCheckedStates();
+      if (IsBuiltInPreset(targetPreset))
+        SaveConfig();                                        // 内置预设沿用主键保存路径
+      else
+        SaveConfig("CurrentPreset");                         // 切换自定义预设时只记录当前项，不回写旧配置
       var item = FindMenuItemByName(trayIcon.ContextMenuStrip.Items, currentPreset);
       if (item != null)
         UpdateCheckedState("presetsGroup", null, item);
@@ -1263,6 +1337,7 @@ namespace OmenSuperHub {
           } else {
             LoadPresetFields(currentPreset);
           }
+          LoadMonitorMetricSettings(currentPreset);
 
           var item = FindMenuItemByName(trayIcon.ContextMenuStrip.Items, currentPreset);
           if (item != null)
@@ -1347,18 +1422,7 @@ namespace OmenSuperHub {
           autoFanProtect = (string)key.GetValue("AutoFanProtect", "on");
           UpdateCheckedState("autoFanProtectGroup", autoFanProtect == "on" ? Strings.FanAutoProtectOn : Strings.FanAutoProtectOff);
 
-          showCPUTemp = Convert.ToBoolean(key.GetValue("ShowCPUTemp", true));
-          showCPUPower = Convert.ToBoolean(key.GetValue("ShowCPUPower", true));
-          showCPUFrequency = Convert.ToBoolean(key.GetValue("ShowCPUFrequency", true));
-          showGPUTemp = Convert.ToBoolean(key.GetValue("ShowGPUTemp", true));
-          showGPUPower = Convert.ToBoolean(key.GetValue("ShowGPUPower", true));
-          showGPUFrequency = Convert.ToBoolean(key.GetValue("ShowGPUFrequency", true));
-          SetMenuItemChecked("showCPUTempGroup", Strings.MonitorCpuTempLabel, showCPUTemp);
-          SetMenuItemChecked("showCPUPowerGroup", Strings.MonitorCpuPowerLabel, showCPUPower);
-          SetMenuItemChecked("showCPUFrequencyGroup", Strings.MonitorCpuFrequencyLabel, showCPUFrequency);
-          SetMenuItemChecked("showGPUTempGroup", Strings.MonitorGpuTempLabel, showGPUTemp);
-          SetMenuItemChecked("showGPUPowerGroup", Strings.MonitorGpuPowerLabel, showGPUPower);
-          SetMenuItemChecked("showGPUFrequencyGroup", Strings.MonitorGpuFrequencyLabel, showGPUFrequency);
+          UpdateMonitorMetricCheckedStates();
 
           appLanguage = (string)key.GetValue("AppLanguage", "zh-CN");
           RestoreLanguageChecked();
@@ -1397,6 +1461,12 @@ namespace OmenSuperHub {
           key.SetValue("MonitorFan", monitorFan);
           key.SetValue("MonitorRefreshRate", monitorRefreshRate);
           key.SetValue("TempDisplayMode", tempDisplayMode);
+          key.SetValue("ShowCPUTemp", showCPUTemp);
+          key.SetValue("ShowCPUPower", showCPUPower);
+          key.SetValue("ShowCPUFrequency", showCPUFrequency);
+          key.SetValue("ShowGPUTemp", showGPUTemp);
+          key.SetValue("ShowGPUPower", showGPUPower);
+          key.SetValue("ShowGPUFrequency", showGPUFrequency);
         }
       } catch { }
     }

--- a/Program.Config.cs
+++ b/Program.Config.cs
@@ -701,6 +701,12 @@ namespace OmenSuperHub {
               key.SetValue("MonitorFan", monitorFan);
               key.SetValue("MonitorRefreshRate", monitorRefreshRate);
               key.SetValue("TempDisplayMode", tempDisplayMode);
+              key.SetValue("ShowCPUTemp", showCPUTemp);
+              key.SetValue("ShowCPUPower", showCPUPower);
+              key.SetValue("ShowCPUFrequency", showCPUFrequency);
+              key.SetValue("ShowGPUTemp", showGPUTemp);
+              key.SetValue("ShowGPUPower", showGPUPower);
+              key.SetValue("ShowGPUFrequency", showGPUFrequency);
               key.SetValue("FloatingBarLoc", floatingBarLoc);
               key.SetValue("FloatingBar", floatingBar);
               key.SetValue("FloatingBarScreen", floatingBarScreen);
@@ -800,6 +806,24 @@ namespace OmenSuperHub {
                   break;
                 case "TempDisplayMode":
                   key.SetValue("TempDisplayMode", tempDisplayMode);
+                  break;
+                case "ShowCPUTemp":
+                  key.SetValue("ShowCPUTemp", showCPUTemp);
+                  break;
+                case "ShowCPUPower":
+                  key.SetValue("ShowCPUPower", showCPUPower);
+                  break;
+                case "ShowCPUFrequency":
+                  key.SetValue("ShowCPUFrequency", showCPUFrequency);
+                  break;
+                case "ShowGPUTemp":
+                  key.SetValue("ShowGPUTemp", showGPUTemp);
+                  break;
+                case "ShowGPUPower":
+                  key.SetValue("ShowGPUPower", showGPUPower);
+                  break;
+                case "ShowGPUFrequency":
+                  key.SetValue("ShowGPUFrequency", showGPUFrequency);
                   break;
                 case "FloatingBarSize":
                   key.SetValue("FloatingBarSize", textSize);
@@ -1322,6 +1346,19 @@ namespace OmenSuperHub {
 
           autoFanProtect = (string)key.GetValue("AutoFanProtect", "on");
           UpdateCheckedState("autoFanProtectGroup", autoFanProtect == "on" ? Strings.FanAutoProtectOn : Strings.FanAutoProtectOff);
+
+          showCPUTemp = Convert.ToBoolean(key.GetValue("ShowCPUTemp", true));
+          showCPUPower = Convert.ToBoolean(key.GetValue("ShowCPUPower", true));
+          showCPUFrequency = Convert.ToBoolean(key.GetValue("ShowCPUFrequency", true));
+          showGPUTemp = Convert.ToBoolean(key.GetValue("ShowGPUTemp", true));
+          showGPUPower = Convert.ToBoolean(key.GetValue("ShowGPUPower", true));
+          showGPUFrequency = Convert.ToBoolean(key.GetValue("ShowGPUFrequency", true));
+          SetMenuItemChecked("showCPUTempGroup", Strings.MonitorCpuTempLabel, showCPUTemp);
+          SetMenuItemChecked("showCPUPowerGroup", Strings.MonitorCpuPowerLabel, showCPUPower);
+          SetMenuItemChecked("showCPUFrequencyGroup", Strings.MonitorCpuFrequencyLabel, showCPUFrequency);
+          SetMenuItemChecked("showGPUTempGroup", Strings.MonitorGpuTempLabel, showGPUTemp);
+          SetMenuItemChecked("showGPUPowerGroup", Strings.MonitorGpuPowerLabel, showGPUPower);
+          SetMenuItemChecked("showGPUFrequencyGroup", Strings.MonitorGpuFrequencyLabel, showGPUFrequency);
 
           appLanguage = (string)key.GetValue("AppLanguage", "zh-CN");
           RestoreLanguageChecked();

--- a/Program.Menu.cs
+++ b/Program.Menu.cs
@@ -1007,6 +1007,21 @@ namespace OmenSuperHub {
       }
 
       menu.Items.Add(new ToolStripSeparator()); // Separator between groups
+      ToolStripMenuItem CreateMonitorMetricItem(string text, string group, Func<bool> getValue, Action<bool> setValue, string configName) {
+        var item = new ToolStripMenuItem(text) {
+          Tag = group,
+          Checked = getValue()
+        };
+        item.Click += (s, e) => {
+          bool value = !getValue();
+          setValue(value);
+          item.Checked = value;
+          SaveConfig(configName);
+          RefreshMonitorDisplay();
+        };
+        return item;
+      }
+
       ToolStripMenuItem hardwareMonitorMenu = new ToolStripMenuItem(Strings.HwMonitor);
       ToolStripMenuItem monitorCPUMenu = new ToolStripMenuItem(Strings.MonitorCpuLabel);
       monitorCPUMenu.DropDownItems.Add(CreateMenuItem(Strings.MonitorCpuOn, "monitorCPUGroup", (s, e) => {
@@ -1014,7 +1029,9 @@ namespace OmenSuperHub {
         monitorCPU = true;
         cpuTempReady = false; // 等待获取到温度后再参与风扇控制
         rawPowerCPU = 0f;     // 清除可能残留的脏功率值
+        rawFrequencyCPU = 0f;
         CPUPower = 0f;
+        CPUFrequency = 0f;
         if (wasAllOff) {
           // 从全关状态重启监控进程
           tempReady = false;
@@ -1036,7 +1053,9 @@ namespace OmenSuperHub {
         monitorCPU = false;
         cpuTempReady = false;
         rawPowerCPU = 0f;  // 关闭时清零，避免重新开启时读到旧值
+        rawFrequencyCPU = 0f;
         CPUPower = 0f;
+        CPUFrequency = 0f;
         SetCpuMonitorState(false);
         // 若CPU和GPU均已关闭，停止监控进程
         if (!monitorCPU && !monitorGPU) {
@@ -1045,6 +1064,10 @@ namespace OmenSuperHub {
         SaveConfig("MonitorCPU");
         // 手动更新勾选状态（因为提前 return 会跳过 CreateMenuItem 的自动勾选）
       }, false));
+      monitorCPUMenu.DropDownItems.Add(new ToolStripSeparator());
+      monitorCPUMenu.DropDownItems.Add(CreateMonitorMetricItem(Strings.MonitorCpuTempLabel, "showCPUTempGroup", () => showCPUTemp, value => showCPUTemp = value, "ShowCPUTemp"));
+      monitorCPUMenu.DropDownItems.Add(CreateMonitorMetricItem(Strings.MonitorCpuPowerLabel, "showCPUPowerGroup", () => showCPUPower, value => showCPUPower = value, "ShowCPUPower"));
+      monitorCPUMenu.DropDownItems.Add(CreateMonitorMetricItem(Strings.MonitorCpuFrequencyLabel, "showCPUFrequencyGroup", () => showCPUFrequency, value => showCPUFrequency = value, "ShowCPUFrequency"));
       hardwareMonitorMenu.DropDownItems.Add(monitorCPUMenu);
       if (hasNVIDIAGpu) {
         ToolStripMenuItem monitorGPUMenu = new ToolStripMenuItem(Strings.MonitorGpuLabel);
@@ -1053,7 +1076,9 @@ namespace OmenSuperHub {
           monitorGPU = true;
           gpuTempReady = false; // 等待获取到温度后再参与风扇控制
           rawPowerGPU = 0f;     // 清除可能残留的脏功率值
+          rawFrequencyGPU = 0f;
           GPUPower = 0f;
+          GPUFrequency = 0f;
           if (hasStopAuto)
             autoStopMonitorGPU = false;
           //重置自动开启标志
@@ -1064,7 +1089,9 @@ namespace OmenSuperHub {
             tempReady = false;
             cpuTempReady = false;
             rawPowerCPU = 0f;
+            rawFrequencyCPU = 0f;
             CPUPower = 0f;
+            CPUFrequency = 0f;
             StartHardwareMonitor();
           } else {
             SetGpuMonitorState(true);
@@ -1082,7 +1109,9 @@ namespace OmenSuperHub {
           monitorGPU = false;
           gpuTempReady = false;
           rawPowerGPU = 0f;  // 关闭时清零，避免重新开启时读到旧值
+          rawFrequencyGPU = 0f;
           GPUPower = 0f;
+          GPUFrequency = 0f;
           if (hasStartAuto)
             autoStartMonitorGPU = false;
           //重置自动关闭标志
@@ -1095,6 +1124,10 @@ namespace OmenSuperHub {
           }
           SaveConfig("MonitorGPU");
         }, false));
+        monitorGPUMenu.DropDownItems.Add(new ToolStripSeparator());
+        monitorGPUMenu.DropDownItems.Add(CreateMonitorMetricItem(Strings.MonitorGpuTempLabel, "showGPUTempGroup", () => showGPUTemp, value => showGPUTemp = value, "ShowGPUTemp"));
+        monitorGPUMenu.DropDownItems.Add(CreateMonitorMetricItem(Strings.MonitorGpuPowerLabel, "showGPUPowerGroup", () => showGPUPower, value => showGPUPower = value, "ShowGPUPower"));
+        monitorGPUMenu.DropDownItems.Add(CreateMonitorMetricItem(Strings.MonitorGpuFrequencyLabel, "showGPUFrequencyGroup", () => showGPUFrequency, value => showGPUFrequency = value, "ShowGPUFrequency"));
         hardwareMonitorMenu.DropDownItems.Add(monitorGPUMenu);
       }
       ToolStripMenuItem monitorFanMenu = new ToolStripMenuItem(Strings.MonitorFanLabel);
@@ -2257,6 +2290,24 @@ namespace OmenSuperHub {
       }
       // 从ContextMenuStrip的根菜单项开始递归
       UpdateMenuItemsCheckedState(trayIcon.ContextMenuStrip.Items, menuItemToCheck);
+    }
+
+    static void SetMenuItemChecked(string group, string itemText, bool isChecked) {
+      if (trayIcon?.ContextMenuStrip == null) return;
+
+      ToolStripMenuItem FindExact(ToolStripItemCollection items) {
+        foreach (ToolStripMenuItem item in items.OfType<ToolStripMenuItem>()) {
+          if (item.Text == itemText && string.Equals(item.Tag as string, group)) return item;
+          if (item.HasDropDownItems) {
+            var found = FindExact(item.DropDownItems);
+            if (found != null) return found;
+          }
+        }
+        return null;
+      }
+
+      var menuItem = FindExact(trayIcon.ContextMenuStrip.Items);
+      if (menuItem != null) menuItem.Checked = isChecked;
     }
 
     // 递归查找指定文本的菜单项

--- a/Program.cs
+++ b/Program.cs
@@ -1439,24 +1439,100 @@ namespace OmenSuperHub {
       return GetPresetDisplayName(currentPreset);
     }
 
+    const int NotifyIconTextLimit = 63;
+
+    static List<string> BuildTrayMonitorLines() {
+      var lines = new List<string>();
+
+      if (monitorCPU && (showCPUTemp || showCPUPower || showCPUFrequency)) {
+        if (cpuTempReady || CPUPower > 0 || CPUFrequency > 0) {
+          var cpuParts = new List<string>();
+          if (showCPUTemp && cpuTempReady) cpuParts.Add($"{CPUTemp:F0}°C");
+          if (showCPUPower && CPUPower > 0) cpuParts.Add($"{CPUPower:F0}W");
+          if (showCPUFrequency && CPUFrequency > 0) cpuParts.Add($"{CPUFrequency / 1000f:F1}G");
+          if (cpuParts.Count > 0) lines.Add($"CPU {string.Join(" ", cpuParts)}");
+          else if (pawnIOState == "RUNNING") lines.Add($"CPU {Strings.MonitorPrepareLabel}");
+        } else if (pawnIOState == "RUNNING") {
+          lines.Add($"CPU {Strings.MonitorPrepareLabel}");
+        } else if (pawnIOState.Length > 0) {
+          lines.Add($"CPU PawnIO {pawnIOState}");
+        }
+      }
+
+      if (monitorGPU && (showGPUTemp || showGPUPower || showGPUFrequency)) {
+        if (pawnIOState == "RUNNING" && !gpuTempReady) {
+          lines.Add(rawPowerGPU < 0
+            ? $"GPU {Strings.GpuPoweredOff}"
+            : $"GPU {Strings.MonitorPrepareLabel}");
+        } else if (pawnIOState.Length > 0) {
+          var gpuParts = new List<string>();
+          if (showGPUTemp && gpuTempReady) gpuParts.Add($"{GPUTemp:F0}°C");
+          if (showGPUPower) gpuParts.Add($"{GPUPower:F0}W");
+          if (showGPUFrequency && GPUFrequency > 0) gpuParts.Add($"{GPUFrequency / 1000f:F1}G");
+          if (gpuParts.Count > 0) lines.Add($"GPU {string.Join(" ", gpuParts)}");
+          else if (pawnIOState == "RUNNING") lines.Add($"GPU {Strings.MonitorPrepareLabel}");
+        }
+      }
+
+      if (monitorFan) {
+        int fanCount = Is3FanNb ? 3 : 2;
+        var fanParts = new List<string>();
+        for (int i = 0; i < fanCount; i++)
+          fanParts.Add((fanSpeedNow[i] * 100).ToString(CultureInfo.CurrentCulture));
+        lines.Add($"Fan {string.Join(" ", fanParts)}");
+      }
+
+      if (lines.Count == 0) lines.Add(Strings.MonitorClosed);
+      return lines;
+    }
+
+    static string EllipsizeUnicode(string value, int maxLength) {
+      if (string.IsNullOrEmpty(value) || value.Length <= maxLength) return value ?? "";
+      if (maxLength <= 0) return "";
+      if (maxLength == 1) return "…";
+
+      int safeEnd = 0;
+      int[] elementIndexes = StringInfo.ParseCombiningCharacters(value);
+      for (int i = 0; i < elementIndexes.Length; i++) {
+        int elementEnd = i + 1 < elementIndexes.Length ? elementIndexes[i + 1] : value.Length;
+        if (elementEnd > maxLength - 1) break;
+        safeEnd = elementEnd;
+      }
+      return value.Substring(0, safeEnd) + "…";
+    }
+
+    static string FormatTrayIconText(string activePresetLabel, string presetName,
+        IList<string> monitorLines, int maxLength) {
+      string monitor = string.Join("\n", monitorLines ?? new List<string>());
+      if (monitor.Length > maxLength)
+        return EllipsizeUnicode(monitor, maxLength);
+
+      string presetLabel = activePresetLabel ?? "";
+      string name = presetName ?? "";
+      int firstLineMaxLength = maxLength - monitor.Length - 1;
+
+      // 至少需要容纳标签和省略号；否则整行预设信息都省略。
+      if (firstLineMaxLength < presetLabel.Length + 1)
+        return monitor;
+
+      string fullPresetLine = presetLabel + name;
+      if (fullPresetLine.Length <= firstLineMaxLength)
+        return fullPresetLine + "\n" + monitor;
+
+      int availableNameLength = firstLineMaxLength - presetLabel.Length;
+      string shortenedName = EllipsizeUnicode(name, availableNameLength);
+      return presetLabel + shortenedName + "\n" + monitor;
+    }
+
     static void UpdateTrayIconText() {
       if (trayIcon == null) return;
 
-      string text = "";
       string presetName = GetCurrentPresetDisplayName();
-      string monitor = monitorText();
-      if (Strings.ActivePreset.Length + presetName.Length + 1 + monitor.Length <= 63) {
-        text = $"{Strings.ActivePreset + presetName}\n{monitor}";
-      } else if (presetName.Length + 1 + monitor.Length <= 63) {
-        text = presetName + "\n" + monitor;
-      } else {
-        text = monitor;
-      }
+      string text = FormatTrayIconText(
+        Strings.ActivePreset, presetName, BuildTrayMonitorLines(), NotifyIconTextLimit);
 
-      const int notifyIconTextLimit = 63;
-      if (text.Length > notifyIconTextLimit)
-        text = text.Substring(0, notifyIconTextLimit);
-
+      // 最终防线：即使未来格式化逻辑发生变化，也不允许 NotifyIcon.Text 超限。
+      text = EllipsizeUnicode(text, NotifyIconTextLimit);
       trayIcon.Text = text;
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -105,6 +105,7 @@ namespace OmenSuperHub {
     static string fanTable = "cool", fanControl = "auto", tempSensitivity = "high", tppPower = "null", iccMax = "null", acLoadline = "null", cpuPower = "null", tgpPower = "on", ppabPower = "on", dState = "normal", autoStart = "off", customIcon = "original", floatingBar = "off", floatingBarLoc = "left", floatingBarScreen = "", omenKey = OmenKeyActions.Default, omenKeyAppPath = "", omenKeyAppName = "", omenKeyShortcut = "", omenKeyPresetCandidates = "", dataLocalize = "off", appLanguage = "zh-CN", autoFanProtect = "on";
     static volatile bool monitorFan = false;
     static bool skipCheckedUpdate = false; // action 内拦截时置 true，阻止 CreateMenuItem 覆盖勾选
+    static bool showCPUTemp = true, showCPUPower = true, showCPUFrequency = true, showGPUTemp = true, showGPUPower = true, showGPUFrequency = true;
     static bool powerOnline = SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online;
     static bool monitorCPU = true, monitorGPU = true, isConnectedToNVIDIA = true, prevIsConnectedToNVIDIA = true, omenKeyTriggered = false; // isTwoBytePL4 = false;
     static bool hasNVIDIAGpu; // 启动时一次性检测，硬件状态不会改变
@@ -115,7 +116,7 @@ namespace OmenSuperHub {
     static int? maxCPUTemp = null;
     static int? maxGPUTemp = null;
     static float CPUTemp = 50, GPUTemp = 40, rawTempCPU = 50f, rawTempGPU = 40f;
-    static float CPUPower = 0, GPUPower = 0, rawPowerCPU = 0f, rawPowerGPU = 0f;
+    static float CPUPower = 0, GPUPower = 0, CPUFrequency = 0f, GPUFrequency = 0f, rawPowerCPU = 0f, rawPowerGPU = 0f, rawFrequencyCPU = 0f, rawFrequencyGPU = 0f;
     static bool rawGotGPU = false;
     static volatile bool tempReady = false;   // 子进程首次输出有效温度后置 true
     static volatile bool cpuTempReady = false; // CPU 温度已初始化给平滑值，允许参与风扇控制
@@ -574,6 +575,8 @@ namespace OmenSuperHub {
       //Console.Error.WriteLine("CRASH: " + $"4: {sw.ElapsedMilliseconds}ms");
       while (true) {
         bool gGpu = false;
+        bool exactCpuClockFound = false;
+        float fCpu = 0, fGpu = 0;
         try {
           foreach (LibreIHardware hw in computer.Hardware) {
             if (hw.HardwareType != LibreHardwareType.Cpu && hw.HardwareType != LibreHardwareType.GpuNvidia && hw.HardwareType != LibreHardwareType.GpuAmd) continue;
@@ -594,6 +597,14 @@ namespace OmenSuperHub {
                     tCpu = sensor.Value.GetValueOrDefault();
                   if (sensor.SensorType == LibreSensorType.Power && sensor.Name.Contains("Package"))
                     pCpu = sensor.Value.GetValueOrDefault();
+                  if (sensor.SensorType == LibreSensorType.Clock && sensor.Value.HasValue) {
+                    if (sensor.Name == "CPU Core" || sensor.Name == "CPU Core #1") {
+                      fCpu = sensor.Value.GetValueOrDefault();
+                      exactCpuClockFound = true;
+                    } else if (!exactCpuClockFound && fCpu <= 0 && sensor.Name != "Bus Speed") {
+                      fCpu = sensor.Value.GetValueOrDefault();
+                    }
+                  }
                 } else if (hw.HardwareType == LibreHardwareType.GpuNvidia || hw.HardwareType == LibreHardwareType.GpuAmd) {
                   if (sensor.SensorType == LibreSensorType.Temperature && sensor.Name == "GPU Core")
                     tGpu = sensor.Value.GetValueOrDefault();
@@ -606,11 +617,13 @@ namespace OmenSuperHub {
                       gGpu = false;
                     }
                   }
+                  if (sensor.SensorType == LibreSensorType.Clock && sensor.Name == "GPU Core" && sensor.Value.HasValue)
+                    fGpu = sensor.Value.GetValueOrDefault();
                 }
               } catch { }
             }
           }
-          Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0:F2};{1:F2};{2:F2};{3:F2};{4}", tCpu, pCpu, tGpu, pGpu, gGpu ? 1 : 0));
+          Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0:F2};{1:F2};{2:F2};{3:F2};{4};{5:F2};{6:F2}", tCpu, pCpu, tGpu, pGpu, gGpu ? 1 : 0, fCpu, fGpu));
         } catch (Exception ex) {
           Console.Error.WriteLine("CRASH: " + ex.Message);
           Environment.Exit(1);
@@ -640,12 +653,18 @@ namespace OmenSuperHub {
         //Debug.WriteLine("[HWMonitor OUT] " + e.Data); // 将子进程输出重定向到VS的输出窗口
         if (e.Data.StartsWith("CRASH:")) return;
         var parts = e.Data.Split(';');
-        if (parts.Length == 5) {
+        if (parts.Length == 5 || parts.Length == 7) {
           if (float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float tc)) rawTempCPU = tc;
           if (float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out float pc) && pc < 9999) rawPowerCPU = pc;
           if (float.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out float tg)) rawTempGPU = tg;
           if (float.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out float pg)) rawPowerGPU = pg;
           rawGotGPU = parts[4] == "1";
+          rawFrequencyCPU = 0f;
+          rawFrequencyGPU = 0f;
+          if (parts.Length == 7) {
+            if (float.TryParse(parts[5], NumberStyles.Float, CultureInfo.InvariantCulture, out float fc)) rawFrequencyCPU = fc;
+            if (float.TryParse(parts[6], NumberStyles.Float, CultureInfo.InvariantCulture, out float fg)) rawFrequencyGPU = fg;
+          }
           // 首次收到数据时，初始化对应传感器的平滑温度
           if (!cpuTempReady) {
             smoothedCPUTemp = rawTempCPU;
@@ -659,6 +678,8 @@ namespace OmenSuperHub {
             gpuTempReady = false;
             GPUTemp = 40;
             GPUPower = 0;
+            rawFrequencyGPU = 0f;
+            GPUFrequency = 0f;
           }
 
           if (!tempReady) {
@@ -904,6 +925,7 @@ namespace OmenSuperHub {
     // CPU监控开 → CPU温度；CPU关GPU开 → GPU温度；均关 → 原版图标（不改 customIcon 设置）
     static void UpdateDynamicIcon() {
       if (customIcon != "dynamic") return;
+      if (trayIcon?.ContextMenuStrip != null && trayIcon.ContextMenuStrip.Visible) return;
       if (monitorCPU) {
         GenerateDynamicIcon((int)CPUTemp);
       } else if (monitorGPU) {
@@ -1141,6 +1163,7 @@ namespace OmenSuperHub {
 
       if (monitorCPU && cpuTempReady) {
         CPUPower = rawPowerCPU;
+        CPUFrequency = rawFrequencyCPU;
       }
       if (monitorGPU) {
         getGPU = rawGotGPU;
@@ -1149,6 +1172,9 @@ namespace OmenSuperHub {
             GPUPower = 0;
           else
             GPUPower = rawPowerGPU;
+          GPUFrequency = rawFrequencyGPU;
+        } else {
+          GPUFrequency = 0f;
         }
       }
 
@@ -1324,13 +1350,20 @@ namespace OmenSuperHub {
 
     // 更新浮窗的文字内容
     static void UpdateFloatingText() {
+      FloatingForm form;
+      lock (_floatingLock) {
+        form = floatingForm;
+      }
+
+      if (form == null || form.IsDisposed) return;
+
       lock (_floatingLock) {
         if (floatingForm == null || floatingForm.IsDisposed) return;
         // debug模式下需取消注释，release模式下需注释以避免打断右键菜单
-        //if (floatingForm.InvokeRequired) {
+        // if (floatingForm.InvokeRequired) {
         //  floatingForm.BeginInvoke(new System.Action(() => UpdateFloatingText()));
         //  return;
-        //}
+        // }
         floatingForm.TopMost = true;
         floatingForm.SetText(monitorText(), textSize, floatingBarLoc, GetFloatingScreen());
       }
@@ -1339,25 +1372,38 @@ namespace OmenSuperHub {
     //生成监控信息
     static string monitorText() {
       string str = "";
-      if (monitorCPU) {
-        if (CPUPower > 0)
-          str += $"CPU: {CPUTemp:F1}°C, {CPUPower:F1}W";
-        else {
+      if (monitorCPU && (showCPUTemp || showCPUPower || showCPUFrequency)) {
+        if (cpuTempReady || CPUPower > 0 || CPUFrequency > 0) {
+          var cpuParts = new List<string>();
+          if (showCPUTemp && cpuTempReady) cpuParts.Add($"{CPUTemp:F1}°C");
+          if (showCPUPower && CPUPower > 0) cpuParts.Add($"{CPUPower:F1}W");
+          if (showCPUFrequency && CPUFrequency > 0) cpuParts.Add($"{CPUFrequency / 1000f:F1}GHz");
+          if (cpuParts.Count > 0) str += $"CPU: {string.Join(", ", cpuParts)}";
+          else if (pawnIOState == "RUNNING") str += $"CPU: {Strings.MonitorPrepareLabel}";
+        } else {
           if (pawnIOState == "RUNNING")
             str += $"CPU: {Strings.MonitorPrepareLabel}";
           else if (pawnIOState.Length > 0)
             str += $"CPU: PawnIO {pawnIOState}";
         }
       }
-      if (monitorGPU) {
+      if (monitorGPU && (showGPUTemp || showGPUPower || showGPUFrequency)) {
         if (str.Length > 0) str += "\n";
         if (pawnIOState == "RUNNING" && !gpuTempReady) {
           if (rawPowerGPU < 0)
             str += $"GPU: {Strings.GpuPoweredOff}";
           else
             str += $"GPU: {Strings.MonitorPrepareLabel}";
-        } else if (pawnIOState.Length > 0)
-          str += $"GPU: {GPUTemp:F1}°C, {GPUPower:F1}W";
+        }
+        else if (pawnIOState.Length > 0)
+        {
+          var gpuParts = new List<string>();
+          if (showGPUTemp && gpuTempReady) gpuParts.Add($"{GPUTemp:F1}°C");
+          if (showGPUPower) gpuParts.Add($"{GPUPower:F1}W");
+          if (showGPUFrequency && GPUFrequency > 0) gpuParts.Add($"{GPUFrequency:F0}MHz");
+          if (gpuParts.Count > 0) str += $"GPU: {string.Join(", ", gpuParts)}";
+          else if (pawnIOState == "RUNNING") str += $"GPU: {Strings.MonitorPrepareLabel}";
+        }
       }
       if (monitorFan) {
         if (str.Length > 0) str += "\n";
@@ -1368,6 +1414,13 @@ namespace OmenSuperHub {
       }
       if (str.Length == 0) str = Strings.MonitorClosed;
       return str;
+    }
+
+    static void RefreshMonitorDisplay() {
+      UpdateTrayIconText();
+      if (floatingForm != null) {
+        floatingForm.SetText(monitorText(), textSize, floatingBarLoc, GetFloatingScreen());
+      }
     }
 
     static string GetPresetDisplayName(string presetKey) {

--- a/Strings.cs
+++ b/Strings.cs
@@ -62,7 +62,7 @@
     public static string PresetCustom1 => T("自定义预设1", "自定義預設1", "Custom 1");
     public static string PresetCustom2 => T("自定义预设2", "自定義預設2", "Custom 2");
     public static string PresetCustom3 => T("自定义预设3", "自定義預設3", "Custom 3");
-    public static string ActivePreset => T("预设：", "預設：", "Preset: ");
+    public static string ActivePreset => T("预设 ", "預設 ", "Preset ");
     public static string RenamePreset => T("重命名", "重新命名", "Rename");
     public static string RenamePresetTitle => T("重命名预设", "重新命名預設", "Rename Preset");
     public static string RenamePresetPrompt => T("请输入新的预设名称：", "請輸入新的預設名稱：", "Please enter new preset name:");

--- a/Strings.cs
+++ b/Strings.cs
@@ -602,6 +602,12 @@
     // ─────────────────────────────────────────────────────────────────────────
     public static string MonitorCpuLabel => T("CPU", "CPU", "CPU");
     public static string MonitorGpuLabel => T("GPU", "GPU", "GPU");
+    public static string MonitorCpuTempLabel => T("CPU温度", "CPU溫度", "CPU Temp");
+    public static string MonitorCpuPowerLabel => T("CPU功率", "CPU功率", "CPU Power");
+    public static string MonitorCpuFrequencyLabel => T("CPU0频率", "CPU0頻率", "CPU0 Frequency");
+    public static string MonitorGpuTempLabel => T("GPU温度", "GPU溫度", "GPU Temp");
+    public static string MonitorGpuPowerLabel => T("GPU功率", "GPU功率", "GPU Power");
+    public static string MonitorGpuFrequencyLabel => T("GPU频率", "GPU頻率", "GPU Frequency");
     public static string MonitorFanLabel => T("风扇", "風扇", "Fan");
     public static string GpuPoweredOff => T("节能", "節能", "PoweredOff");
     public static string MonitorPrepareLabel => T("数据获取中...", "數據獲取中...", "Retrieving data...");


### PR DESCRIPTION
## 主要变更

- 在硬件监控菜单中新增频率显示项：
  - CPU0频率
  - GPU频率
- 新增频率显示开关，并保存到现有注册表配置中。
- 浮窗和托盘 tooltip 支持显示：
  - CPU0频率：`x.xG`
  - GPU频率：`x.xG`

## 为什么选择 CPU0

`CPU0频率` 表示第一个 CPU 核心的频率。

选择第一个核心的原因是：在常见 P/E 核架构中，第一个核心通常是 P 核；而降频、性能限制、功耗墙等场景下，用户一般更关心 P 核的实时频率。相比读取平均频率，CPU0 更能反映主要性能核心当前是否被降频。

如果平台没有明确的 `CPU Core #1` 传感器，则会回退读取第一个非 `Bus Speed` 的 CPU Clock 传感器。

## 实现方式

- CPU 频率复用 LibreHardwareMonitor 的 `SensorType.Clock`。
- 为本地 LibreHardwareMonitor 的 Intel / AMD CPU 补充 CPU Clock 传感器。
- GPU 频率优先读取 LibreHardwareMonitor 的 `GPU Core` Clock。
- 为 NVIDIA GPU 补充 `GPU Core` Clock 传感器，使用已有 NvAPI 接口读取当前核心频率。
- 主程序解析监控数据时兼容旧字段格式，频率不可用时不显示 `0.0GHz` 或 `0MHz`。


## 测试环境

- 机型：HP 光影精灵 9
- CPU：Intel Core i5-13500H
- GPU：NVIDIA GeForce RTX 4050 laptop